### PR TITLE
Number of citations

### DIFF
--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -80,12 +80,11 @@ class Property:
         if self._nb_citations is None:
             if self.bibsource is None:
                 self.nb_citations = 0
+            elif "doi" in self.bibsource.fields:
+                doi = self.bibsource.fields['doi']
+                self.nb_citations = get_nb_citations(doi)
             else:
-                try:
-                    doi = self.bibsource.fields['doi']
-                    self.nb_citations = get_nb_citations(doi)
-                except KeyError:
-                    self.nb_citations = 0
+                self.nb_citations = 0
         return self._nb_citations
     
     @nb_citations.setter

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -78,11 +78,14 @@ class Property:
     def nb_citations(self):
         # if nb_citations doesn't already exist, compute it
         if self._nb_citations is None:
-            try:
-                doi = self.bibsource.fields['doi']
-                self.nb_citations = get_nb_citations(doi)
-            except KeyError:
+            if self.bibsource is None:
                 self.nb_citations = 0
+            else:
+                try:
+                    doi = self.bibsource.fields['doi']
+                    self.nb_citations = get_nb_citations(doi)
+                except KeyError:
+                    self.nb_citations = 0
         return self._nb_citations
     
     @nb_citations.setter

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires=
     numpy >= 1.9
     matplotlib >= 3.2.2
     pybtex==0.24.0
+    crossrefapi==1.5.0
     scipy >= 1.8
 
 [options.package_data]

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -61,3 +61,14 @@ def test_warning_overwriting_year():
         match="year argument will be ignored since a bib source was found",
     ):
         htm.Property(source=source_bib_as_string, year=2010)
+
+
+def test_nb_citations():
+    my_prop = htm.Property(source=source_bib_from_file)
+    assert my_prop.nb_citations > 0
+
+def test_nb_citations_no_citations_with_unknown_source():
+    my_prop = htm.Property(source="coucou")
+
+    assert my_prop.nb_citations == 0
+


### PR DESCRIPTION
This PR fixes #47 by using crossref API to get the number of citation of a reference.


Usage:

```python
import h_transport_materials as htm

my_prop = htm.Property(source="alberro_experimental_2015")
print(my_prop.nb_citations)
```