### PR TITLE
Add pint capabilities

### DIFF
--- a/h_transport_materials/__init__.py
+++ b/h_transport_materials/__init__.py
@@ -22,6 +22,10 @@ from pathlib import Path
 
 bib_database = parse_file(str(Path(__file__).parent) + "/references.bib")
 
+import pint
+
+ureg = pint.UnitRegistry()
+
 from .property import (
     Property,
     ArrheniusProperty,

--- a/h_transport_materials/properties_group.py
+++ b/h_transport_materials/properties_group.py
@@ -132,6 +132,8 @@ class PropertiesGroup(list):
         for prop in self:
 
             prop_dict = {key: getattr(prop, key) for key in keys if hasattr(prop, key)}
+            if "units" in prop_dict:
+                prop_dict["units"] = f"{prop_dict['units']:~}"
             data.append(prop_dict)
 
         with open(filename, "w") as outfile:

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -164,6 +164,7 @@ class ArrheniusProperty(Property):
                 fit experimental points. Defaults to None.
             kwargs: other Property arguments
         """
+        self.units = pint.Unit("")
         self.pre_exp = pre_exp
         self.act_energy = act_energy
         self.data_T = data_T

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 import numpy as np
 from crossref.restful import Works, Etiquette
 import pint

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -164,7 +164,6 @@ class ArrheniusProperty(Property):
                 fit experimental points. Defaults to None.
             kwargs: other Property arguments
         """
-        self.units = pint.Unit("")
         self.pre_exp = pre_exp
         self.act_energy = act_energy
         self.data_T = data_T

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -156,8 +156,8 @@ class ArrheniusProperty(Property):
         property = pre_exp * exp( - act_energy/(k_B T) )
 
         Args:
-            pre_exp (float, optional): the pre-exponential factor. Defaults to None.
-            act_energy (float, optional): the activation energy in eV. Defaults to None.
+            pre_exp (float or pint.Quantity, optional): the pre-exponential factor. Defaults to None.
+            act_energy (float or pint.Quantity, optional): the activation energy. Defaults to None.
             data_T (list, optional): list of temperatures in K. Used to automatically
                 fit experimental points. Defaults to None.
             data_y (list, optional): list of y data. Used to automatically
@@ -268,8 +268,8 @@ class Solubility(ArrheniusProperty):
 
     Args:
         units (str): units of the solubility "m-3 Pa-1/2" or "m-3 Pa-1".
-        S_0 (float, optional): pre-exponential factor. Defaults to None.
-        E_S (float, optional): activation energy (eV). Defaults to None.
+        S_0 (float or pint.Quantity, optional): pre-exponential factor. Defaults to None.
+        E_S (float or pint.Quantity, optional): activation energy. Defaults to None.
     """
 
     def __init__(
@@ -291,7 +291,7 @@ class Solubility(ArrheniusProperty):
         Material: {self.material}
         Year: {self.year}
         Isotope: {self.isotope}
-        Pre-exponential factor: {self.pre_exp} c
+        Pre-exponential factor: {self.pre_exp} {self.units:~}
         Activation energy: {self.act_energy} eV
         """
         return val
@@ -301,8 +301,8 @@ class Diffusivity(ArrheniusProperty):
     """Diffusivity class
 
     Args:
-        D_0 (float, optional): pre-exponential factor (m2/s). Defaults to None.
-        E_D (float, optional): activation energy (eV). Defaults to None.
+        D_0 (float or pint.Quantity, optional): pre-exponential factor. Defaults to None.
+        E_D (float or pint.Quantity, optional): activation energy. Defaults to None.
     """
 
     def __init__(self, D_0: float = None, E_D: float = None, **kwargs) -> None:
@@ -336,7 +336,7 @@ class Permeability(ArrheniusProperty):
         Material: {self.material}
         Year: {self.year}
         Isotope: {self.isotope}
-        Pre-exponential factor: {self.pre_exp} m-1 Pa-1/2 s-1
+        Pre-exponential factor: {self.pre_exp} {self.units:~}
         Activation energy: {self.act_energy} eV
         """
         return val
@@ -355,7 +355,7 @@ class RecombinationCoeff(ArrheniusProperty):
         Material: {self.material}
         Year: {self.year}
         Isotope: {self.isotope}
-        Pre-exponential factor: {self.pre_exp} m4/s
+        Pre-exponential factor: {self.pre_exp} {self.units:~}
         Activation energy: {self.act_energy} eV
         """
         return val
@@ -374,7 +374,7 @@ class DissociationCoeff(ArrheniusProperty):
         Material: {self.material}
         Year: {self.year}
         Isotope: {self.isotope}
-        Pre-exponential factor: {self.pre_exp} m-3 Pa-1
+        Pre-exponential factor: {self.pre_exp} {self.units:~}
         Activation energy: {self.act_energy} eV
         """
         return val

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -202,6 +202,9 @@ class ArrheniusProperty(Property):
         if isinstance(value, pint.Quantity):
             self._pre_exp = value.to(self.units).magnitude
         else:  # assume it's given in the correct units
+            warnings.warn(
+                f"no units were given with pre-exponential factor, assuming {self.units:~}"
+            )
             self._pre_exp = value
 
     @property
@@ -215,6 +218,9 @@ class ArrheniusProperty(Property):
         if isinstance(value, pint.Quantity):
             self._act_energy = value.to(DEFAULT_ENERGY_UNITS).magnitude
         else:
+            warnings.warn(
+                f"no units were given with activation energy, assuming {DEFAULT_ENERGY_UNITS:~}"
+            )
             self._act_energy = value
 
     @property

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -182,6 +182,10 @@ class ArrheniusProperty(Property):
         return val
 
     @property
+    def units(self):
+        return pint.Unit("")
+
+    @property
     def range(self):
         if self._range is None and self.data_T is not None:
             self.fit()
@@ -281,15 +285,22 @@ class Solubility(ArrheniusProperty):
     def __init__(
         self, units: str, S_0: float = None, E_S: float = None, **kwargs
     ) -> None:
+        self.units = units
+        super().__init__(pre_exp=S_0, act_energy=E_S, **kwargs)
 
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
         acceptable_units = ["m-3 Pa-1/2", "m-3 Pa-1"]
-        if units == "m-3 Pa-1/2":
-            self.units = ureg.particle * ureg.meter**-3 * ureg.Pa**-0.5
-        elif units == "m-3 Pa-1":
-            self.units = ureg.particle * ureg.meter**-3 * ureg.Pa**-1
+        if value == "m-3 Pa-1/2":
+            self._units = ureg.particle * ureg.meter**-3 * ureg.Pa**-0.5
+        elif value == "m-3 Pa-1":
+            self._units = ureg.particle * ureg.meter**-3 * ureg.Pa**-1
         else:
             raise ValueError("units can only accept {} or {}".format(*acceptable_units))
-        super().__init__(pre_exp=S_0, act_energy=E_S, **kwargs)
 
     def __str__(self) -> str:
         val = f"""
@@ -312,7 +323,6 @@ class Diffusivity(ArrheniusProperty):
     """
 
     def __init__(self, D_0: float = None, E_D: float = None, **kwargs) -> None:
-        self.units = ureg.meter**2 * ureg.second**-1
         super().__init__(pre_exp=D_0, act_energy=E_D, **kwargs)
 
     def __str__(self) -> str:
@@ -326,14 +336,15 @@ class Diffusivity(ArrheniusProperty):
         """
         return val
 
+    @property
+    def units(self):
+        return ureg.meter**2 * ureg.second**-1
+
 
 class Permeability(ArrheniusProperty):
     """Permeability class"""
 
     def __init__(self, **kwargs) -> None:
-        self.units = (
-            ureg.particle * ureg.meter**-1 * ureg.second**-1 * ureg.Pa**-0.5
-        )
         super().__init__(**kwargs)
 
     def __str__(self) -> str:
@@ -346,13 +357,16 @@ class Permeability(ArrheniusProperty):
         Activation energy: {self.act_energy} eV
         """
         return val
+
+    @property
+    def units(self):
+        return ureg.particle * ureg.meter**-1 * ureg.second**-1 * ureg.Pa**-0.5
 
 
 class RecombinationCoeff(ArrheniusProperty):
     """RecombinationCoeff class"""
 
     def __init__(self, **kwargs) -> None:
-        self.units = ureg.meter**4 * ureg.second**-1
         super().__init__(**kwargs)
 
     def __str__(self) -> str:
@@ -365,13 +379,16 @@ class RecombinationCoeff(ArrheniusProperty):
         Activation energy: {self.act_energy} eV
         """
         return val
+
+    @property
+    def units(self):
+        return ureg.meter**4 * ureg.second**-1
 
 
 class DissociationCoeff(ArrheniusProperty):
     """DissociationCoeff class"""
 
     def __init__(self, **kwargs) -> None:
-        self.units = ureg.meter**-3 * ureg.Pa**-1
         super().__init__(**kwargs)
 
     def __str__(self) -> str:
@@ -384,6 +401,10 @@ class DissociationCoeff(ArrheniusProperty):
         Activation energy: {self.act_energy} eV
         """
         return val
+
+    @property
+    def units(self):
+        return ureg.meter**-3 * ureg.Pa**-1
 
 
 def get_nb_citations(doi: str):

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires=
     pybtex==0.24.0
     crossrefapi==1.5.0
     scipy >= 1.8
+    pint
 
 [options.package_data]
 * = *.csv, *.bib

--- a/tests/test_diffusivity.py
+++ b/tests/test_diffusivity.py
@@ -1,0 +1,18 @@
+import h_transport_materials as htm
+
+
+def test_pre_exp_can_be_quantity():
+    prop = htm.Diffusivity(
+        D_0=1 * htm.ureg.cm**2 * htm.ureg.second**-1,
+        E_D=0.5,
+    )
+
+    assert prop.pre_exp == 1e-4
+
+
+def test_act_energy_can_be_quantity():
+    prop = htm.Diffusivity(
+        D_0=1,
+        E_D=0.5 * htm.ureg.kJ * htm.ureg.mol**-1,
+    )
+    assert prop.act_energy != 0.5

--- a/tests/test_properties_group.py
+++ b/tests/test_properties_group.py
@@ -147,4 +147,7 @@ def test_export_to_json():
                     for item1, item2 in zip(val, getattr(prop_ref, key)):
                         assert item1 == item2
                 else:
-                    assert getattr(prop_ref, key) == val
+                    if key == "units":
+                        assert f"{getattr(prop_ref, key):~}" == val
+                    else:
+                        assert getattr(prop_ref, key) == val

--- a/tests/test_solubility.py
+++ b/tests/test_solubility.py
@@ -12,3 +12,19 @@ def test_units_wrong_value(units):
         ValueError, match="units can only accept m-3 Pa-1/2 or m-3 Pa-1"
     ):
         htm.Solubility(units=units)
+
+
+def test_pre_exp_can_be_quantity():
+    htm.Solubility(
+        units="m-3 Pa-1/2",
+        S_0=1 * htm.ureg.particle * htm.ureg.meter**-3 * htm.ureg.bar**-0.5,
+        E_S=0.5,
+    )
+
+
+def test_act_energy_can_be_quantity():
+    htm.Solubility(
+        units="m-3 Pa-1/2",
+        S_0=1,
+        E_S=0.5*htm.ureg.kJ * htm.ureg.mol**-1,
+    )


### PR DESCRIPTION
This PR fixes #74 by adding pint conversions.

This is a non-breaking change as when no units are provided, default units are assumed (eV for activation energies, and default uunits otherwise).

Ultimately, we can get rid of all the conversion functions we implemented but that can be done in another PR.