### PR TITLE
Sieverts vs henry

### DIFF
--- a/docs/user/defining_property.rst
+++ b/docs/user/defining_property.rst
@@ -35,8 +35,8 @@ More precise classes can also be used like :class:`Diffusivity() <h_transport_ma
     from h_transport_materials import Diffusivity, Solubility, Permeability
 
     my_diff = Diffusivity(D_0=1, E_D=0.2)
-    my_sol = Solubility(S_0=1, E_S=0.2)
-    my_perm = Permeability(pre_exp=1, act_energy=0.2)
+    my_sol = Solubility(S_0=1, E_S=0.2, law="henry")
+    my_perm = Permeability(pre_exp=1, act_energy=0.2, law="sievert")
 
 Note, :class:`Solubility() <h_transport_materials.property.Solubility>` has a `units` argument because depending on the material, the units can be m-3 Pa-1/2 (Sievert's law of solubility) or m-3 Pa-1 (Henry's law of solubility).
 

--- a/docs/user/defining_property.rst
+++ b/docs/user/defining_property.rst
@@ -35,8 +35,8 @@ More precise classes can also be used like :class:`Diffusivity() <h_transport_ma
     from h_transport_materials import Diffusivity, Solubility, Permeability
 
     my_diff = Diffusivity(D_0=1, E_D=0.2)
-    my_sol = Solubility(units="m-3 Pa-1/2", S_0=1, E_S=0.2)
-    my_perm = Permeability(pre_exp=1, act_energy=0.2)
+    # my_sol = Solubility(S_0=1, E_S=0.2)
+    # my_perm = Permeability(pre_exp=1, act_energy=0.2)
 
 Note, :class:`Solubility() <h_transport_materials.property.Solubility>` has a `units` argument because depending on the material, the units can be m-3 Pa-1/2 (Sievert's law of solubility) or m-3 Pa-1 (Henry's law of solubility).
 

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -272,7 +272,7 @@ class ArrheniusProperty(Property):
             warnings.warn(f"no units were given with data_T, assuming {ureg.K:~}")
             value *= ureg.K
 
-        value = self._remove_nan_in_experimental_points(value, label="data_T")
+        value = self._remove_nan_in_experimental_points(value)
 
         self._data_T = value
 
@@ -294,33 +294,28 @@ class ArrheniusProperty(Property):
         else:
             warnings.warn(f"no units were given with data_y, assuming {self.units:~}")
             value *= self.units
-        value = self._remove_nan_in_experimental_points(value, label="data_y")
+        value = self._remove_nan_in_experimental_points(value)
 
         self._data_y = value
 
-    def _remove_nan_in_experimental_points(self, quantity: pint.Quantity, label: str):
-        """_summary_
+    def _remove_nan_in_experimental_points(self, quantity: pint.Quantity):
+        """Removes all nan values from a list of values
 
         Args:
-            quantity (pint.Quantity): _description_
-            label (str): _description_
+            quantity (pint.Quantity): the quantity with magnitude as a list
 
         Raises:
-            TypeError: _description_
+            TypeError: if the magnitude is not a list of a numpy array
 
         Returns:
-            _type_: _description_
+            pint.Quantity: the values without nans
         """
         if not isinstance(quantity.magnitude, (list, np.ndarray)):
-            raise TypeError(f"{label} accepts list or np.ndarray")
-        elif isinstance(quantity.magnitude, list):
-            quantity_as_array = np.array(quantity)
-            quantity = quantity_as_array[
-                ~np.isnan(quantity_as_array)
-            ]  # remove nan values
-        else:
-            quantity = quantity[~np.isnan(quantity)]
-        return quantity
+            raise TypeError("data_T and data_y accept list or np.ndarray")
+        quantity_mag = np.asarray(quantity.magnitude)
+        quantity_mag = quantity_mag[~np.isnan(quantity_mag)]
+
+        return ureg.Quantity(quantity_mag, quantity.units)
 
     def fit(self):
         pre_exp, act_energy = fit_arhenius(self.data_y, self.data_T)
@@ -371,7 +366,7 @@ class Solubility(ArrheniusProperty):
             value = value.to(self.units)
         else:
             raise ValueError("units are required for Solubility")
-        value = self._remove_nan_in_experimental_points(value, label="data_y")
+        value = self._remove_nan_in_experimental_points(value)
 
         self._data_y = value
 
@@ -440,7 +435,7 @@ class Permeability(ArrheniusProperty):
             value = value.to(self.units)
         else:
             raise ValueError("units are required for Permeability")
-        value = self._remove_nan_in_experimental_points(value, label="data_y")
+        value = self._remove_nan_in_experimental_points(value)
 
         self._data_y = value
 

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -373,12 +373,29 @@ class Diffusivity(ArrheniusProperty):
 class Permeability(ArrheniusProperty):
     """Permeability class"""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, law: str, **kwargs) -> None:
+        self.law = law
         super().__init__(**kwargs)
 
     @property
+    def law(self):
+        return self._law
+
+    @law.setter
+    def law(self, value):
+        acceptable_values = ["henry", "sievert"]
+        if value not in acceptable_values:
+            raise ValueError(f"law attribute must be one of {acceptable_values}")
+        self._law = value
+
+    @property
     def units(self):
-        return ureg.particle * ureg.meter**-1 * ureg.second**-1 * ureg.Pa**-0.5
+        if self.law == "sievert":
+            return (
+                ureg.particle * ureg.meter**-1 * ureg.second**-1 * ureg.Pa**-0.5
+            )
+        elif self.law == "henry":
+            return ureg.particle * ureg.meter**-1 * ureg.second**-1 * ureg.Pa**-1
 
 
 class RecombinationCoeff(ArrheniusProperty):

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -332,9 +332,7 @@ class Solubility(ArrheniusProperty):
         E_S (float or pint.Quantity, optional): activation energy. Defaults to None.
     """
 
-    def __init__(
-        self, units=None, S_0: float = None, E_S: float = None, **kwargs
-    ) -> None:
+    def __init__(self, S_0: float = None, E_S: float = None, **kwargs) -> None:
         super().__init__(pre_exp=S_0, act_energy=E_S, **kwargs)
 
     @ArrheniusProperty.pre_exp.setter

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -271,13 +271,8 @@ class ArrheniusProperty(Property):
         else:
             warnings.warn(f"no units were given with data_T, assuming {ureg.K:~}")
             value *= ureg.K
-        if not isinstance(value.magnitude, (list, np.ndarray)):
-            raise TypeError("data_T accepts list or np.ndarray")
-        elif isinstance(value.magnitude, list):
-            value_as_array = np.array(value)
-            value = value_as_array[~np.isnan(value_as_array)]  # remove nan values
-        else:
-            value = value[~np.isnan(value)]
+
+        value = self._remove_nan_in_experimental_points(value, label="data_T")
 
         self._data_T = value
 
@@ -299,15 +294,33 @@ class ArrheniusProperty(Property):
         else:
             warnings.warn(f"no units were given with data_y, assuming {self.units:~}")
             value *= self.units
-        if not isinstance(value.magnitude, (list, np.ndarray)):
-            raise TypeError("data_y accepts list or np.ndarray")
-        elif isinstance(value.magnitude, list):
-            value_as_array = np.array(value)
-            value = value_as_array[~np.isnan(value_as_array)]  # remove nan values
-        else:
-            value = value[~np.isnan(value)]
+        value = self._remove_nan_in_experimental_points(value, label="data_y")
 
         self._data_y = value
+
+    def _remove_nan_in_experimental_points(self, quantity: pint.Quantity, label: str):
+        """_summary_
+
+        Args:
+            quantity (pint.Quantity): _description_
+            label (str): _description_
+
+        Raises:
+            TypeError: _description_
+
+        Returns:
+            _type_: _description_
+        """
+        if not isinstance(quantity.magnitude, (list, np.ndarray)):
+            raise TypeError(f"{label} accepts list or np.ndarray")
+        elif isinstance(quantity.magnitude, list):
+            quantity_as_array = np.array(quantity)
+            quantity = quantity_as_array[
+                ~np.isnan(quantity_as_array)
+            ]  # remove nan values
+        else:
+            quantity = quantity[~np.isnan(quantity)]
+        return quantity
 
     def fit(self):
         pre_exp, act_energy = fit_arhenius(self.data_y, self.data_T)
@@ -358,13 +371,7 @@ class Solubility(ArrheniusProperty):
             value = value.to(self.units)
         else:
             raise ValueError("units are required for Solubility")
-        if not isinstance(value.magnitude, (list, np.ndarray)):
-            raise TypeError("data_y accepts list or np.ndarray")
-        elif isinstance(value.magnitude, list):
-            value_as_array = np.array(value)
-            value = value_as_array[~np.isnan(value_as_array)]  # remove nan values
-        else:
-            value = value[~np.isnan(value)]
+        value = self._remove_nan_in_experimental_points(value, label="data_y")
 
         self._data_y = value
 
@@ -433,13 +440,7 @@ class Permeability(ArrheniusProperty):
             value = value.to(self.units)
         else:
             raise ValueError("units are required for Permeability")
-        if not isinstance(value.magnitude, (list, np.ndarray)):
-            raise TypeError("data_y accepts list or np.ndarray")
-        elif isinstance(value.magnitude, list):
-            value_as_array = np.array(value)
-            value = value_as_array[~np.isnan(value_as_array)]  # remove nan values
-        else:
-            value = value[~np.isnan(value)]
+        value = self._remove_nan_in_experimental_points(value, label="data_y")
 
         self._data_y = value
 

--- a/h_transport_materials/property_database/aluminium/aluminium.py
+++ b/h_transport_materials/property_database/aluminium/aluminium.py
@@ -19,7 +19,6 @@ young_diffusivity = Diffusivity(
 
 ransley_solubility = Solubility(
     isotope="H",
-    units="m-3 Pa-1/2",
     S_0=2.32e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=39.7 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(723 * htm.ureg.K, 873 * htm.ureg.K),

--- a/h_transport_materials/property_database/beryllium.py
+++ b/h_transport_materials/property_database/beryllium.py
@@ -15,7 +15,6 @@ abramov_diffusivity = Diffusivity(
 
 
 shapovalov_solubility = Solubility(
-    units="m-3 Pa-1/2",
     isotope="H",
     S_0=1.90e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=16.8 * htm.ureg.kJ * htm.ureg.mol**-1,

--- a/h_transport_materials/property_database/carbon.py
+++ b/h_transport_materials/property_database/carbon.py
@@ -24,7 +24,6 @@ atsumi_diffusivity = Diffusivity(
 )
 
 atsumi_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.9e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=-19.2 * htm.ureg.kJ * htm.ureg.mol**-1,
     source="atsumi_absorption_1988",

--- a/h_transport_materials/property_database/copper/copper.py
+++ b/h_transport_materials/property_database/copper/copper.py
@@ -26,7 +26,6 @@ reiter_solubility_copper = Solubility(
     range=(470 * htm.ureg.K, 1200 * htm.ureg.K),
     source="reiter_compilation_1996",
     isotope="T",
-    units="m-3 Pa-1/2",
 )
 
 # copper = Material(D=reiter_diffusivity_copper, S=reiter_solubility_copper, name="copper")
@@ -90,7 +89,6 @@ eichenauer_solubility_copper_h = Solubility(
     range=(700 * htm.ureg.K, 920 * htm.ureg.K),
     source="eichenauer_notitle_1957",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 # ################# Perkins 1973 #############################
@@ -127,7 +125,6 @@ eichenauer_solubility_copper_d = Solubility(
     range=(703 * htm.ureg.K, 913 * htm.ureg.K),
     source="eichenauer_notitle_1965",
     isotope="D",
-    units="m-3 Pa-1/2",
 )
 
 # ################# Anderl 1990 #############################
@@ -175,7 +172,6 @@ thomas_solubility_copper_h = Solubility(
     range=(770 * htm.ureg.K, 1320 * htm.ureg.K),
     source="thomas_solubility_1967",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 # ################# Wampler 1976 #############################
@@ -185,7 +181,6 @@ wampler_solubility_copper_h = Solubility(
     range=(770 * htm.ureg.K, 1070 * htm.ureg.K),
     source="wampler_precipitation_1976",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 data_T_mclellan = (
@@ -237,7 +232,6 @@ data_y_mclellan *= (
 mclellan_solubility = Solubility(
     data_T=data_T_mclellan,
     data_y=data_y_mclellan,
-    units="m-3 Pa-1/2",
     isotope="H",
     source="mclellan_solid_1973",
 )

--- a/h_transport_materials/property_database/cucrzr/cucrzr.py
+++ b/h_transport_materials/property_database/cucrzr/cucrzr.py
@@ -72,7 +72,6 @@ serra_solubility_h = Solubility(
     range=(553 * htm.ureg.K, 773 * htm.ureg.K),
     source="serra_hydrogen_1998",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 serra_solubility_d = Solubility(
@@ -84,7 +83,6 @@ serra_solubility_d = Solubility(
     range=(553 * htm.ureg.K, 773 * htm.ureg.K),
     source="serra_hydrogen_1998",
     isotope="D",
-    units="m-3 Pa-1/2",
 )
 # ################# Noh 2016 #############################
 nog_diffusivity_cucrzr_t = Diffusivity(
@@ -101,7 +99,6 @@ nog_solubility_cucrzr_t_1 = Solubility(
     range=(573 * htm.ureg.K, 873 * htm.ureg.K),
     source="noh_hydrogen-isotope_2016",
     isotope="T",
-    units="m-3 Pa-1/2",
 )
 
 nog_solubility_cucrzr_t_2 = Solubility(
@@ -110,7 +107,6 @@ nog_solubility_cucrzr_t_2 = Solubility(
     range=(573 * htm.ureg.K, 873 * htm.ureg.K),
     source="noh_hydrogen-isotope_2016",
     isotope="T",
-    units="m-3 Pa-1/2",
 )
 
 # ################# Anderl 1999 #############################
@@ -137,7 +133,6 @@ penalva_solubility_cucrzr_h = Solubility(
     range=(593 * htm.ureg.K, 773 * htm.ureg.K),
     source="penalva_interaction_2012",
     isotope="D",
-    units="m-3 Pa-1/2",
 )
 
 anderl_recombination = RecombinationCoeff(

--- a/h_transport_materials/property_database/flibe/flibe.py
+++ b/h_transport_materials/property_database/flibe/flibe.py
@@ -34,7 +34,6 @@ calderoni_diffusivity = Diffusivity(
 )
 
 calderoni_solubility = Solubility(
-    units="m-3 Pa-1",
     S_0=7.9e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
     E_S=35 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(
@@ -55,7 +54,6 @@ anderl_diffusivity = Diffusivity(
 )
 
 anderl_solubility = Solubility(
-    units="m-3 Pa-1",
     data_T=np.array([600, 650]) * htm.ureg.degC,
     data_y=[3.1e-4, 1.0e-4] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
     source="anderl_deuteriumtritium_2004",
@@ -85,7 +83,6 @@ data_solubility_field_h *= flibe_density_field
 data_solubility_field_h *= 1 / flibe_mass_field
 
 field_solubility_h = Solubility(
-    units="m-3 Pa-1",
     data_T=np.array([500, 600, 700]) * htm.ureg.degC,
     data_y=data_solubility_field_h,
     source="field_solubilities_1967",
@@ -98,7 +95,6 @@ data_solubility_field_d *= flibe_density_field
 data_solubility_field_d *= 1 / flibe_mass_field
 
 field_solubility_d = Solubility(
-    units="m-3 Pa-1",
     data_T=np.array([500, 600, 700]) * htm.ureg.degC,
     data_y=data_solubility_field_d,
     source="field_solubilities_1967",
@@ -116,7 +112,6 @@ data_maulinauskas_k_c_d = [1.41e-3, 2.74e-3, 4.26e-3]  # Kc adimensionnal
 data_maulinauskas_sol_d = data_maulinauskas_k_c_d / htm.Rg / data_maulinauskas_T
 
 maulinauskas_solubility_h = Solubility(
-    units="m-3 Pa-1",
     data_T=data_maulinauskas_T,
     data_y=data_maulinauskas_sol_h,
     isotope="H",
@@ -124,7 +119,6 @@ maulinauskas_solubility_h = Solubility(
 )
 
 maulinauskas_solubility_d = Solubility(
-    units="m-3 Pa-1",
     data_T=data_maulinauskas_T,
     data_y=data_maulinauskas_sol_d,
     isotope="D",

--- a/h_transport_materials/property_database/flinak/flinak.py
+++ b/h_transport_materials/property_database/flinak/flinak.py
@@ -28,7 +28,6 @@ fukada_solubility_h = Solubility(
     data_y=data_fukada_S[:, 1] * htm.ureg.mol * htm.ureg.cm**-3 * htm.ureg.atm**-1,
     source="fukada_hydrogen_2006",
     isotope="H",
-    units="m-3 Pa-1",
 )
 
 # nakamura 2015
@@ -53,7 +52,6 @@ nakamura_solubility_h = Solubility(
     data_y=data_nakamura_S[:, 1] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
     source="nakamura_hydrogen_2015",
     isotope="H",
-    units="m-3 Pa-1",
 )
 
 # lam 2020
@@ -102,7 +100,6 @@ zeng_solubility_h_2019 = Solubility(
     data_y=data_zeng_S[:, 1] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
     source="zeng_behavior_2019",
     isotope="H",
-    units="m-3 Pa-1",
 )
 
 
@@ -131,7 +128,6 @@ zeng_solubility_h_2014 = Solubility(
     data_y=data_zeng_2014_S[:, 1] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
     source="zeng_apparatus_2014",
     isotope="H",
-    units="m-3 Pa-1",
 )
 
 properties = [

--- a/h_transport_materials/property_database/gold.py
+++ b/h_transport_materials/property_database/gold.py
@@ -16,7 +16,6 @@ eichenauer_diffusivity = Diffusivity(
 
 
 shimada_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=7.8e1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=99.4 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(773 * htm.ureg.K, 873 * htm.ureg.K),
@@ -56,7 +55,6 @@ data_y_mclellan *= (
 mclellan_solubility = Solubility(
     data_T=data_T_mclellan,
     data_y=data_y_mclellan,
-    units="m-3 Pa-1/2",
     source="mclellan_solid_1973",
     isotope="H",
 )

--- a/h_transport_materials/property_database/hastelloy_n.py
+++ b/h_transport_materials/property_database/hastelloy_n.py
@@ -53,7 +53,6 @@ zhang_diffusivity_d = Diffusivity(
 )
 
 zhang_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.36e-7 * u.mol * u.m**-3 * u.Pa**-0.5,
     E_S=17.60 * u.kJ * u.mol**-1,
     range=(u.Quantity(400, u.degC), u.Quantity(800, u.degC)),
@@ -62,7 +61,6 @@ zhang_solubility_h = Solubility(
 )
 
 zhang_solubility_d = Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.31e-7 * u.mol * u.m**-3 * u.Pa**-0.5,
     E_S=17.81 * u.kJ * u.mol**-1,
     range=(u.Quantity(400, u.degC), u.Quantity(800, u.degC)),

--- a/h_transport_materials/property_database/hastelloy_x.py
+++ b/h_transport_materials/property_database/hastelloy_x.py
@@ -16,7 +16,6 @@ kishimoto_diffusivity = Diffusivity(
 )
 
 kishimoto_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=41 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
     E_S=0.22 * htm.ureg.eV * htm.ureg.particle**-1,
     isotope="H",

--- a/h_transport_materials/property_database/incoloy_800.py
+++ b/h_transport_materials/property_database/incoloy_800.py
@@ -31,7 +31,6 @@ schmidt_permeability = Permeability(
 
 
 schmidt_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=schmidt_permeability.pre_exp / schmidt_diffusivity.pre_exp,
     E_S=schmidt_permeability.act_energy - schmidt_diffusivity.act_energy,
     range=(1023 * u.K, 1223 * u.K),
@@ -58,7 +57,6 @@ esteban_diffusivity = Diffusivity(
 )
 
 esteban_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.102 * u.mol * u.m**-3 * u.Pa**-0.5,
     E_S=7.8 * u.kJ * u.mol**-1,
     range=(427 * u.K, 780 * u.K),

--- a/h_transport_materials/property_database/inconel_600.py
+++ b/h_transport_materials/property_database/inconel_600.py
@@ -16,7 +16,6 @@ kishimoto_diffusivity = Diffusivity(
 )
 
 kishimoto_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=36 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
     E_S=0.22 * htm.ureg.eV * htm.ureg.particle**-1,
     isotope="H",
@@ -90,7 +89,6 @@ rota_permeability_d = Permeability(
 )
 
 rota_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.4e17 * htm.ureg.particle * htm.ureg.cm**-3 * htm.ureg.mbar**-0.5,
     E_S=1.3 * htm.ureg.kcal * htm.ureg.mol**-1,
     isotope="H",
@@ -102,7 +100,6 @@ rota_solubility_h = Solubility(
 )
 
 rota_solubility_d = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.2e17 * htm.ureg.particle * htm.ureg.cm**-3 * htm.ureg.mbar**-0.5,
     E_S=1.2 * htm.ureg.kcal * htm.ureg.mol**-1,
     isotope="D",

--- a/h_transport_materials/property_database/inconel_625.py
+++ b/h_transport_materials/property_database/inconel_625.py
@@ -5,7 +5,6 @@ from h_transport_materials import (
     DissociationCoeff,
     RecombinationCoeff,
 )
-import h_transport_materials.conversion as c
 
 
 gervasini_diffusivity_H = Diffusivity(
@@ -25,7 +24,6 @@ gervasini_diffusivity_D = Diffusivity(
 )
 
 gervasini_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=2.09e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=10.52 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(650 * htm.ureg.K, 900 * htm.ureg.K),

--- a/h_transport_materials/property_database/inconel_750.py
+++ b/h_transport_materials/property_database/inconel_750.py
@@ -16,7 +16,6 @@ kishimoto_diffusivity = Diffusivity(
 )
 
 kishimoto_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=14 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
     E_S=0.12 * htm.ureg.eV * htm.ureg.particle**-1,
     isotope="H",

--- a/h_transport_materials/property_database/iron.py
+++ b/h_transport_materials/property_database/iron.py
@@ -33,7 +33,6 @@ tahara_diffusivity_D = Diffusivity(
 )
 
 eichenauer_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=4.90e-6
     / IRON_MOLAR_VOLUME
     * htm.ureg.mol

--- a/h_transport_materials/property_database/lipb/lipb.py
+++ b/h_transport_materials/property_database/lipb/lipb.py
@@ -47,7 +47,6 @@ wu_solubility = Solubility(
     range=(850 * u.K, 1040 * u.K),
     source="wu_solubility_1983",
     isotope="D",
-    units="m-3 Pa-1/2",
 )
 
 
@@ -57,7 +56,6 @@ chan_solubility = Solubility(
     range=(573 * u.K, 773 * u.K),
     source="chan_thermodynamic_1984",
     isotope="H",
-    units="m-3 Pa-1/2",
     note="extrapolated to Pb-17Li",
 )
 
@@ -68,7 +66,6 @@ katsuta_solubility = Solubility(
     range=(573 * u.K, 723 * u.K),
     source="katsuta_hydrogen_1985",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 
@@ -86,7 +83,6 @@ fauvet_solubility = Solubility(
     range=(722 * u.K, 724 * u.K),  # TODO should be 723 link to issue #37
     source="fauvet_hydrogen_1988",
     isotope="H",
-    units="m-3 Pa-1/2",
     note="Fauvet gives the value for 723 K only",
 )
 
@@ -111,7 +107,6 @@ schumacher_solubility = Solubility(
     data_y=schumacher_solubility_data_y,
     source="schumacher_hydrogen_1990",
     isotope="H",
-    units="m-3 Pa-1/2",
     note="in the review of E.Mas de les Valls there's a mistake in the conversion and"
     + "the activation energy of solubility should be positive"
     + "We decided to refit Schumacher's data",
@@ -162,7 +157,6 @@ reiter_solubility_h = Solubility(
     range=(508 * u.K, 700 * u.K),
     source="reiter_solubility_1991",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 reiter_solubility_data_D = reiter_solubility_data[2:, 2:]
@@ -180,7 +174,6 @@ reiter_solubility_d = Solubility(
     range=(508 * u.K, 700 * u.K),
     source="reiter_solubility_1991",
     isotope="D",
-    units="m-3 Pa-1/2",
 )
 
 reiter_solubility_t = Solubility(
@@ -189,7 +182,6 @@ reiter_solubility_t = Solubility(
     range=(508 * u.K, 700 * u.K),
     source="reiter_solubility_1991",
     isotope="T",
-    units="m-3 Pa-1/2",
 )
 
 
@@ -204,7 +196,6 @@ aiello_solubility = Solubility(
     range=(600 * u.K, 900 * u.K),
     source="aiello_determination_2006",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 
@@ -229,7 +220,6 @@ alberro_solubility = Solubility(
     range=(523 * u.K, 922 * u.K),
     source="alberro_experimental_2015",
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 
@@ -273,7 +263,6 @@ edao_diffusivity_d = Diffusivity(
 
 
 edao_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     S_0=2.73e-7 * u.atfr * u.Pa**-0.5 * atom_density_lipb(nb_li=17, nb_pb=83),
     E_S=4.18 * u.kJ * u.mol**-1,
     isotope="H",
@@ -283,7 +272,6 @@ edao_solubility_h = Solubility(
 )
 
 edao_solubility_d = Solubility(
-    units="m-3 Pa-1/2",
     S_0=4.21e-7 * u.atfr * u.Pa**-0.5 * atom_density_lipb(nb_li=17, nb_pb=83),
     E_S=3.10 * u.kJ * u.mol**-1,
     isotope="D",
@@ -329,7 +317,6 @@ okitsu_diffusivity_d = Diffusivity(
 )
 
 okitsu_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     S_0=8.6e-5 * u.atfr * u.Pa**-0.5 * atom_density_lipb(nb_li=17, nb_pb=83),
     E_S=53800 * u.kJ * u.mol**-1,
     range=(773 * u.K, 973 * u.K),
@@ -339,7 +326,6 @@ okitsu_solubility_h = Solubility(
 )
 
 okitsu_solubility_d = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.1e-4 * u.atfr * u.Pa**-0.5 * atom_density_lipb(nb_li=17, nb_pb=83),
     E_S=55200 * u.kJ * u.mol**-1,
     range=(773 * u.K, 973 * u.K),

--- a/h_transport_materials/property_database/lithium/lithium.py
+++ b/h_transport_materials/property_database/lithium/lithium.py
@@ -36,7 +36,6 @@ veleckis_solubility = Solubility(
     ),
     source="veleckis_lithium-lithium_1974",
     isotope="H",
-    units="m-3 Pa-1/2",
     note="table 1 of original paper",
 )
 
@@ -49,7 +48,6 @@ smith_sol_data_y_h **= -1
 smith_sol_data_y_h *= 1 / LITHIUM_MOLAR_VOLUME
 
 smith_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     data_T=htm.ureg.Quantity([700, 750, 800, 850, 900, 950, 1000], htm.ureg.degC),
     data_y=smith_sol_data_y_h,
     isotope="H",
@@ -66,7 +64,6 @@ smith_sol_data_y_d **= -1
 smith_sol_data_y_d *= 1 / LITHIUM_MOLAR_VOLUME
 
 smith_solubility_d = Solubility(
-    units="m-3 Pa-1/2",
     data_T=htm.ureg.Quantity([700, 750, 800, 850, 900, 950, 1000], htm.ureg.degC),
     data_y=smith_sol_data_y_d,
     isotope="D",
@@ -83,7 +80,6 @@ smith_sol_data_y_t **= -1
 smith_sol_data_y_t *= 1 / LITHIUM_MOLAR_VOLUME
 
 smith_solubility_t = Solubility(
-    units="m-3 Pa-1/2",
     data_T=htm.ureg.Quantity([700, 750, 800, 850, 900, 950, 1000], htm.ureg.degC),
     data_y=smith_sol_data_y_t,
     isotope="T",

--- a/h_transport_materials/property_database/molybdenum.py
+++ b/h_transport_materials/property_database/molybdenum.py
@@ -20,7 +20,6 @@ katsuta_diffusivity = Diffusivity(
 )
 
 tanabe_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=3.3 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=37.4 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(500 * htm.ureg.K, 1100 * htm.ureg.K),
@@ -29,7 +28,6 @@ tanabe_solubility = Solubility(
 )
 
 katsuta_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=np.exp(8.703) * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=7.863e3 * htm.ureg.K * htm.k_B,
     isotope="H",

--- a/h_transport_materials/property_database/nickel.py
+++ b/h_transport_materials/property_database/nickel.py
@@ -5,7 +5,6 @@ from h_transport_materials import (
     Permeability,
     DissociationCoeff,
 )
-import h_transport_materials.conversion as c
 
 NI_MOLAR_VOLUME = 6.59e-6  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/nickel
 u = htm.ureg
@@ -53,7 +52,6 @@ louthan_diffusivity_T = Diffusivity(
 )
 
 robertson_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=5.52e-6 / NI_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5,
     E_S=12.5 * u.kJ * u.mol**-1,
     range=(273 * u.K, 1673 * u.K),
@@ -65,7 +63,6 @@ robertson_solubility = Solubility(
 
 
 louthan_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=5.5e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
     E_S=15.8 * u.kJ * u.mol**-1,
     range=(300 * u.K, 500 * u.K),

--- a/h_transport_materials/property_database/nimonic_80A.py
+++ b/h_transport_materials/property_database/nimonic_80A.py
@@ -16,7 +16,6 @@ kishimoto_diffusivity = Diffusivity(
 )
 
 kishimoto_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=17 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
     E_S=0.12 * htm.ureg.eV * htm.ureg.particle**-1,
     isotope="H",

--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -1,6 +1,5 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 
 NIOBIUM_MOLAR_VOLUME = 1.08e-8  # m3/mol https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/niobium
 
@@ -20,7 +19,6 @@ schober_diffusivity = Diffusivity(
 )
 
 veleckis_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.26e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=-35.3 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(625 * htm.ureg.K, 944 * htm.ureg.K),
@@ -29,7 +27,6 @@ veleckis_solubility = Solubility(
 )
 
 reiter_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=3.6e-6
     / NIOBIUM_MOLAR_VOLUME
     * htm.ureg.mol

--- a/h_transport_materials/property_database/palladium.py
+++ b/h_transport_materials/property_database/palladium.py
@@ -89,7 +89,6 @@ favreau_data_y = (
 favreau_data_y *= 1 / PALLADIUM_VOLUMIC_DENSITY  # mol T m-3  cmHg-1.2
 
 favreau_solubility_t = Solubility(
-    units="m-3 Pa-1/2",
     data_T=favreau_data_T * htm.ureg.degC,
     data_y=favreau_data_y,
     # S_0=4.45e-1 * htm.avogadro_nb,
@@ -250,7 +249,6 @@ favreau_data_y_h = (
 favreau_data_y_h *= 1 / PALLADIUM_VOLUMIC_DENSITY  # mol T m-3  cmHg-1.2
 
 favreau_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     data_T=favreau_data_T_h * htm.ureg.degC,
     data_y=favreau_data_y_h,
     source="favreau_solubility_1954",

--- a/h_transport_materials/property_database/pdag/palladium_silver.py
+++ b/h_transport_materials/property_database/pdag/palladium_silver.py
@@ -38,7 +38,6 @@ serra_solubility_data = np.genfromtxt(
 )
 
 serra_solubility_h = Solubility(
-    units="m-3 Pa-1/2",
     data_T=1000 / serra_solubility_data["hydrogenX"] * u.K,
     data_y=serra_solubility_data["hydrogenY"] * u.mol * u.m**-3 * u.Pa**-0.5,
     isotope="H",
@@ -46,7 +45,6 @@ serra_solubility_h = Solubility(
 )
 
 serra_solubility_d = Solubility(
-    units="m-3 Pa-1/2",
     data_T=1000 / serra_solubility_data["deuteriumX"] * u.K,
     data_y=serra_solubility_data["deuteriumY"] * u.mol * u.m**-3 * u.Pa**-0.5,
     isotope="D",

--- a/h_transport_materials/property_database/rafm_steel.py
+++ b/h_transport_materials/property_database/rafm_steel.py
@@ -12,7 +12,6 @@ causey_diffusivity = Diffusivity(
 )
 
 causey_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=4.40e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=28.6 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(300 * htm.ureg.K, 973 * htm.ureg.K),
@@ -34,7 +33,6 @@ forcey_diffusivity = htm.Diffusivity(
 )
 
 forcey_solubility = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.29
     * htm.ureg.mol
     * htm.ureg.m**-3
@@ -58,7 +56,6 @@ serra_diffusivity_f82h = htm.Diffusivity(
     isotope="D",
 )
 serra_solubility_f82h = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.377 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=26880 * htm.ureg.J * htm.ureg.mol**-1,
     range=(373 * htm.ureg.K, 743 * htm.ureg.K),
@@ -78,7 +75,6 @@ serra_diffusivity_batman = htm.Diffusivity(
     note="Batman steel",
 )
 serra_solubility_batman = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.198 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=24703 * htm.ureg.J * htm.ureg.mol**-1,
     range=(373 * htm.ureg.K, 743 * htm.ureg.K),
@@ -98,7 +94,6 @@ pisarev_diffusivity = htm.Diffusivity(
 )
 
 pisarev_solubility = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=2.0e18 * htm.ureg.particle * htm.ureg.cm**-3 * htm.ureg.Pa**-0.5,
     E_S=0.343 * htm.ureg.eV * htm.ureg.particle**-1,
     range=(573 * htm.ureg.K, 873 * htm.ureg.K),
@@ -118,7 +113,6 @@ esteban_diffusivity_h = htm.Diffusivity(
 )
 
 esteban_solubility_h = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.328 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=29005 * htm.ureg.J * htm.ureg.mol**-1,
     range=(423 * htm.ureg.K, 892 * htm.ureg.K),
@@ -135,7 +129,6 @@ esteban_diffusivity_d = htm.Diffusivity(
 )
 
 esteban_solubility_d = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.325 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=28955 * htm.ureg.J * htm.ureg.mol**-1,
     range=(423 * htm.ureg.K, 892 * htm.ureg.K),
@@ -154,7 +147,6 @@ esteban_diffusivity_t = htm.Diffusivity(
 )
 
 esteban_solubility_t = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=0.271 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=27905 * htm.ureg.J * htm.ureg.mol**-1,
     range=(423 * htm.ureg.K, 892 * htm.ureg.K),
@@ -199,7 +191,6 @@ kulsartov_diffusivity_h = htm.Diffusivity(
 )
 
 kulsartov_solubility_h = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=7.7 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=33 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(
@@ -222,7 +213,6 @@ kulsartov_diffusivity_d = htm.Diffusivity(
     source="kulsartov_investigation_2006",
 )
 kulsartov_solubility_d = htm.Solubility(
-    units="m-3 Pa-1/2",
     S_0=7.4 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=36 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(

--- a/h_transport_materials/property_database/series_300_steel.py
+++ b/h_transport_materials/property_database/series_300_steel.py
@@ -13,7 +13,6 @@ perng_diffusivity = Diffusivity(
 )
 
 perng_solubility = Solubility(
-    units="m-3 Pa-1/2",
     range=(373 * htm.ureg.K, 623 * htm.ureg.K),
     S_0=2.70e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=6.9 * htm.ureg.kJ * htm.ureg.mol**-1,

--- a/h_transport_materials/property_database/silver.py
+++ b/h_transport_materials/property_database/silver.py
@@ -26,7 +26,6 @@ data_y_mclellan *= 1 / SILVER_MOLAR_VOLUME  # in m-3 Pa-1/2
 mclellan_solubility = Solubility(
     data_T=data_T_mclellan * htm.ureg.degC,
     data_y=data_y_mclellan * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    units="m-3 Pa-1/2",
     source="mclellan_solid_1973",
     isotope="H",
     note="there is likely a mistake in Shimada's 2020 Review",

--- a/h_transport_materials/property_database/ss_304.py
+++ b/h_transport_materials/property_database/ss_304.py
@@ -30,7 +30,6 @@ grant_diffusivity = Diffusivity(
 )
 
 grant_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=grant_permeability.pre_exp / grant_diffusivity.pre_exp,
     E_S=grant_permeability.act_energy - grant_diffusivity.act_energy,
     range=(645 * u.K, 965 * u.K),
@@ -104,7 +103,6 @@ braun_diffusivity = Diffusivity(
 )
 
 hawkins_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=2.2e19 * u.particle * u.cm**-3 * u.bar**-0.5,
     E_S=1700 * u.J * u.mol**-1,
     source="N.L. Hawkins, Report KAPL 863 (1953)",

--- a/h_transport_materials/property_database/steel_316L/steel_316L.py
+++ b/h_transport_materials/property_database/steel_316L/steel_316L.py
@@ -20,7 +20,6 @@ reiter_diffusivity = Diffusivity(
 )
 
 reiter_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=5.8e-6
     / IRON_MOLAR_VOLUME
     * htm.ureg.mol
@@ -66,7 +65,6 @@ kishimoto_diffusivity = Diffusivity(
 )
 
 kishimoto_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=16 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
     E_S=0.13 * htm.ureg.eV * htm.ureg.particle**-1,
     isotope="H",
@@ -146,7 +144,6 @@ forcey_diffusivity = Diffusivity(
 )
 
 forcey_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.50 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=18510 * htm.ureg.kJ * htm.ureg.mol**-1,
     range=(
@@ -214,7 +211,6 @@ lee_diffusivity = Diffusivity(
 )
 lee_data_invT = lee_diffsol_data["solubilityX"] * htm.ureg.K**-1
 lee_solubility = Solubility(
-    units="m-3 Pa-1/2",
     data_T=1 / lee_data_invT,
     data_y=lee_diffsol_data["solubilityY"]
     * htm.ureg.mol

--- a/h_transport_materials/property_database/tantalum.py
+++ b/h_transport_materials/property_database/tantalum.py
@@ -12,7 +12,6 @@ volkl_diffusivity = Diffusivity(
 )
 
 veleckis_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.32e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=-33.7 * htm.ureg.kJ * htm.ureg.mol**-1,
     isotope="H",

--- a/h_transport_materials/property_database/titanium.py
+++ b/h_transport_materials/property_database/titanium.py
@@ -14,7 +14,6 @@ reiter_diffusivity = Diffusivity(
 )
 
 reiter_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=1.06e-5
     / TITANIUM_MOLAR_VOLUME
     * htm.ureg.mol

--- a/h_transport_materials/property_database/tungsten/tungsten.py
+++ b/h_transport_materials/property_database/tungsten/tungsten.py
@@ -22,7 +22,6 @@ frauenfelder_solubility = Solubility(
     range=(1100 * htm.ureg.K, 2400 * htm.ureg.K),
     source=frauenfelder_src,
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 
@@ -119,7 +118,6 @@ esteban_solubility_tungsten_h = Solubility(
     range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
     source=esteban_src,
     isotope="H",
-    units="m-3 Pa-1/2",
 )
 
 esteban_solubility_tungsten_d = Solubility(
@@ -128,7 +126,6 @@ esteban_solubility_tungsten_d = Solubility(
     range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
     source=esteban_src,
     isotope="D",
-    units="m-3 Pa-1/2",
 )
 
 esteban_solubility_tungsten_t = Solubility(
@@ -137,7 +134,6 @@ esteban_solubility_tungsten_t = Solubility(
     range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
     source=esteban_src,
     isotope="T",
-    units="m-3 Pa-1/2",
 )
 
 holzner_src = "holzner_solute_2020"

--- a/h_transport_materials/property_database/vanadium.py
+++ b/h_transport_materials/property_database/vanadium.py
@@ -1,6 +1,5 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 
 VANADIUM_MOLAR_VOLUME = 8.34e-6  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/vanadium
 
@@ -13,7 +12,6 @@ volk_diffusivity = Diffusivity(
 )
 
 veleckis_solubility = Solubility(
-    units="m-3 Pa-1/2",
     isotope="H",
     range=(519 * htm.ureg.K, 827 * htm.ureg.K),
     S_0=1.38e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
@@ -34,7 +32,6 @@ schober_diffusivity = Diffusivity(
 )  # TODO get data from experimental points, see issue #64
 
 reiter_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=2.1e-6
     / VANADIUM_MOLAR_VOLUME
     * htm.ureg.mol

--- a/h_transport_materials/property_database/vanadium_alloy.py
+++ b/h_transport_materials/property_database/vanadium_alloy.py
@@ -12,7 +12,6 @@ hashizume_diffusivity = Diffusivity(
 )
 
 klepikov_solubility = Solubility(
-    units="m-3 Pa-1/2",
     data_T=[673.0, 773.0, 873.0, 973.0, 1073.0] * htm.ureg.K,
     data_y=[1.62e20, 9.84e19, 5.65e19, 4.91e19, 2.94e19]
     * htm.ureg.particle

--- a/h_transport_materials/property_database/zirconium/zirconium.py
+++ b/h_transport_materials/property_database/zirconium/zirconium.py
@@ -23,7 +23,6 @@ hsu_diffusivity = Diffusivity(
 )
 
 kearns_solubility = Solubility(
-    units="m-3 Pa-1/2",
     S_0=4.30e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
     E_S=-49.5 * htm.ureg.kJ * htm.ureg.mol**-1,
     isotope="H",
@@ -39,7 +38,6 @@ yamanaka_solubility_data = np.genfromtxt(
 )
 
 yamanaka_solubility = Solubility(
-    units="m-3 Pa-1/2",
     data_T=1e4 / yamanaka_solubility_data[:, 0] * htm.ureg.K,
     data_y=np.exp(yamanaka_solubility_data[:, 1])
     / ZIRCONIUM_MOLAR_VOLUME

--- a/tests/test_permeability.py
+++ b/tests/test_permeability.py
@@ -3,12 +3,25 @@ import h_transport_materials as htm
 
 def test_permeability_henry():
     """Tests that a Henry permeability can be set"""
-    htm.Permeability(
+    prop = htm.Permeability(
         pre_exp=1
         * htm.ureg.particle
         * htm.ureg.meter**-1
         * htm.ureg.second**-1
         * htm.ureg.Pa**-1,
         act_energy=1 * htm.ureg.eV * htm.ureg.particle**-1,
-        law="henry",
     )
+    assert prop.law == "henry"
+
+
+def test_permeability_sievert():
+    """Tests that a Sievert permeability can be set"""
+    prop = htm.Permeability(
+        pre_exp=1
+        * htm.ureg.particle
+        * htm.ureg.meter**-1
+        * htm.ureg.second**-1
+        * htm.ureg.Pa**-0.5,
+        act_energy=1 * htm.ureg.eV * htm.ureg.particle**-1,
+    )
+    assert prop.law == "sievert"

--- a/tests/test_permeability.py
+++ b/tests/test_permeability.py
@@ -1,3 +1,5 @@
+import pytest
+
 import h_transport_materials as htm
 
 
@@ -25,3 +27,15 @@ def test_permeability_sievert():
         act_energy=1 * htm.ureg.eV * htm.ureg.particle**-1,
     )
     assert prop.law == "sievert"
+
+
+def test_users_have_to_give_units_pre_exp():
+    with pytest.raises(ValueError, match="units are required for Permeability"):
+        htm.Permeability(
+            pre_exp=1, act_energy=0.1 * htm.ureg.eV * htm.ureg.particle**-1
+        )
+
+
+def test_users_have_to_give_units_data_y():
+    with pytest.raises(ValueError, match="units are required for Permeability"):
+        htm.Permeability(data_y=[1, 2], data_T=[1, 2] * htm.ureg.K)

--- a/tests/test_permeability.py
+++ b/tests/test_permeability.py
@@ -1,0 +1,14 @@
+import h_transport_materials as htm
+
+
+def test_permeability_henry():
+    """Tests that a Henry permeability can be set"""
+    htm.Permeability(
+        pre_exp=1
+        * htm.ureg.particle
+        * htm.ureg.meter**-1
+        * htm.ureg.second**-1
+        * htm.ureg.Pa**-1,
+        act_energy=1 * htm.ureg.eV * htm.ureg.particle**-1,
+        law="henry",
+    )

--- a/tests/test_properties_group.py
+++ b/tests/test_properties_group.py
@@ -182,7 +182,6 @@ def test_units_property():
         E_D=0.1 * htm.ureg.eV * htm.ureg.particle**-1,
     )
     sol = htm.Solubility(
-        units="m-3 Pa-1",
         S_0=1 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-1,
         E_S=0.1 * htm.ureg.eV * htm.ureg.particle**-1,
     )

--- a/tests/test_solubility.py
+++ b/tests/test_solubility.py
@@ -1,14 +1,3 @@
 import pytest
 
 import h_transport_materials as htm
-
-
-@pytest.mark.parametrize(
-    "units",
-    ["coucou", True, 0, 1, "mol m-3 Pa-1/2", "mol m-3 Pa-1"],
-)
-def test_units_wrong_value(units):
-    with pytest.raises(
-        ValueError, match="units can only accept m-3 Pa-1/2 or m-3 Pa-1"
-    ):
-        htm.Solubility(units=units)

--- a/tests/test_solubility.py
+++ b/tests/test_solubility.py
@@ -1,3 +1,13 @@
 import pytest
 
 import h_transport_materials as htm
+
+
+def test_users_have_to_give_units_pre_exp():
+    with pytest.raises(ValueError, match="units are required for Solubility"):
+        htm.Solubility(S_0=1, E_S=0.1 * htm.ureg.eV * htm.ureg.particle**-1)
+
+
+def test_users_have_to_give_units_data_y():
+    with pytest.raises(ValueError, match="units are required for Solubility"):
+        htm.Solubility(data_y=[1, 2], data_T=[1, 2] * htm.ureg.K)


### PR DESCRIPTION
Fixes #154

For `Solubility` and `Permeability` classes the units are now identified directly from the pre-exponential factor dimensionality.
This removes the need of the `units` argument