### PR TITLE
Default behaviour for Solubility and Permeability units

### DIFF
--- a/docs/user/defining_property.rst
+++ b/docs/user/defining_property.rst
@@ -35,8 +35,8 @@ More precise classes can also be used like :class:`Diffusivity() <h_transport_ma
     from h_transport_materials import Diffusivity, Solubility, Permeability
 
     my_diff = Diffusivity(D_0=1, E_D=0.2)
-    # my_sol = Solubility(S_0=1, E_S=0.2)
-    # my_perm = Permeability(pre_exp=1, act_energy=0.2)
+    my_sol = Solubility(S_0=1, E_S=0.2)
+    my_perm = Permeability(pre_exp=1, act_energy=0.2)
 
 Note, :class:`Solubility() <h_transport_materials.property.Solubility>` has a `units` argument because depending on the material, the units can be m-3 Pa-1/2 (Sievert's law of solubility) or m-3 Pa-1 (Henry's law of solubility).
 

--- a/tests/test_permeability.py
+++ b/tests/test_permeability.py
@@ -39,3 +39,9 @@ def test_users_have_to_give_units_pre_exp():
 def test_users_have_to_give_units_data_y():
     with pytest.raises(ValueError, match="units are required for Permeability"):
         htm.Permeability(data_y=[1, 2], data_T=[1, 2] * htm.ureg.K)
+
+
+@pytest.mark.filterwarnings("ignore:no units were given")
+def test_without_units_but_law():
+    prop = htm.Permeability(1, 0, law="sievert")
+    assert prop.pre_exp.units == prop.units

--- a/tests/test_solubility.py
+++ b/tests/test_solubility.py
@@ -11,3 +11,9 @@ def test_users_have_to_give_units_pre_exp():
 def test_users_have_to_give_units_data_y():
     with pytest.raises(ValueError, match="units are required for Solubility"):
         htm.Solubility(data_y=[1, 2], data_T=[1, 2] * htm.ureg.K)
+
+
+@pytest.mark.filterwarnings("ignore:no units were given")
+def test_without_units_but_law():
+    prop = htm.Solubility(1, 0, law="sievert")
+    assert prop.pre_exp.units == prop.units


### PR DESCRIPTION
This allows users to specify the solubility law in order to have default units