### PR TITLE
Fix Okitsu diffusivities

### DIFF
--- a/h_transport_materials/property_database/lipb/lipb.py
+++ b/h_transport_materials/property_database/lipb/lipb.py
@@ -299,16 +299,16 @@ edao_permeability_d_bis = Permeability(
 )
 
 okitsu_diffusivity_h = Diffusivity(
-    D_0=2.0e8 * u.m**2 * u.s**-1,
+    D_0=2.0e-8 * u.m**2 * u.s**-1,
     E_D=11200 * u.J * u.mol**-1,
     range=(773 * u.K, 973 * u.K),
     isotope="H",
     source="okitsu_analysis_2012",
-    note="Li17Pb83",
+    note="Li17Pb83. Typo in Okitsu's paper on the pre-exponential factor",
 )
 
 okitsu_diffusivity_d = Diffusivity(
-    D_0=4.8e8 * u.m**2 * u.s**-1,
+    D_0=4.8e-8 * u.m**2 * u.s**-1,
     E_D=20300 * u.J * u.mol**-1,
     range=(773 * u.K, 973 * u.K),
     isotope="D",

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -47,3 +47,10 @@ def test_all_properties_have_reasonable_activation_energies():
     for prop in htm.database:
         print(prop)
         assert abs(prop.act_energy) < 4 * htm.ureg.eV * htm.ureg.particle**-1
+
+
+def test_all_diffusivities_have_reasonable_pre_exp():
+    """Checks that all the diffusivities have pre_exp factors below 100 m2/s"""
+    for prop in htm.diffusivities:
+        print(prop)
+        assert abs(prop.pre_exp) < 100 * htm.ureg.m**2 * htm.ureg.s**-1


### PR DESCRIPTION
The diffusivities of Okitsu for FLiBe were wrong due to a typo in the paper.

This PR fixes them and fixes #167 in the mean time