### PR TITLE
Units for mean()

### DIFF
--- a/h_transport_materials/properties_group.py
+++ b/h_transport_materials/properties_group.py
@@ -92,9 +92,15 @@ class PropertiesGroup(list):
             default_range (tuple, optional): temperature range taken if
                 a Property doesn't have range. Defaults to (300, 1200).
 
+        Raises:
+            ValueError: When called on a mixed units group
+
         Returns:
             ArrheniusProperty: the mean arrhenius property
         """
+        if self.units == "mixed units":
+            raise ValueError("Can't compute mean on mixed units groups")
+
         # initialise data points
         data_T = np.array([])
         data_y = np.array([])

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -184,10 +184,16 @@ class ArrheniusProperty(Property):
 
     @property
     def units(self):
-        if not hasattr(self, "pre_exp"):
-            return ureg.dimensionless
-        else:
+        # check if data_y is set
+        if hasattr(self, "data_y"):
+            if self.data_y is not None:
+                return self.data_y.units
+        # check if pre_exp is set
+        if hasattr(self, "pre_exp"):
             return self.pre_exp.units
+
+        # return dimensionless by default
+        return ureg.dimensionless
 
     @property
     def range(self):

--- a/h_transport_materials/property.py
+++ b/h_transport_materials/property.py
@@ -184,7 +184,10 @@ class ArrheniusProperty(Property):
 
     @property
     def units(self):
-        return ureg.dimensionless
+        if not hasattr(self, "pre_exp"):
+            return ureg.dimensionless
+        else:
+            return self.pre_exp.units
 
     @property
     def range(self):

--- a/tests/test_properties_group.py
+++ b/tests/test_properties_group.py
@@ -200,3 +200,16 @@ def test_to_latex_table():
 
 def test_mean_has_units():
     assert htm.diffusivities.mean().units == htm.ureg.m**2 * htm.ureg.s**-1
+
+
+def test_cannot_compute_mean_on_mixed_groups():
+    prop1 = htm.ArrheniusProperty(
+        0.1 * htm.ureg.dimensionless, 0.1 * htm.ureg.eV * htm.ureg.particle**-1
+    )
+    prop2 = htm.ArrheniusProperty(
+        0.1 * htm.ureg.m, 0.1 * htm.ureg.eV * htm.ureg.particle**-1
+    )
+    my_group = htm.PropertiesGroup([prop1, prop2])
+
+    with pytest.raises(ValueError, match="Can't compute mean on mixed units groups"):
+        my_group.mean()

--- a/tests/test_properties_group.py
+++ b/tests/test_properties_group.py
@@ -88,7 +88,7 @@ def test_mean(mean_D_0, mean_E_D):
     mean_prop = my_group.mean()
 
     # test
-    assert mean_prop.pre_exp == pytest.approx(mean_D_0, rel=0.2)
+    assert mean_prop.pre_exp.magnitude == pytest.approx(mean_D_0, rel=0.2)
     assert mean_prop.act_energy.magnitude == pytest.approx(mean_E_D, rel=0.2)
 
 
@@ -196,3 +196,7 @@ def test_units_property():
 
 def test_to_latex_table():
     htm.diffusivities.to_latex_table()
+
+
+def test_mean_has_units():
+    assert htm.diffusivities.mean().units == htm.ureg.m**2 * htm.ureg.s**-1


### PR DESCRIPTION
Fixes #137 by changing the units property in ArrheniusProperty which detects the units from the pre_exponential factor or data_y.

Also, an error is raised when trying to compute the mean of a group with mixed units