### PR TITLE
Improve unit readability

### DIFF
--- a/h_transport_materials/property_database/alumina/alumina.py
+++ b/h_transport_materials/property_database/alumina/alumina.py
@@ -7,6 +7,7 @@ from h_transport_materials import (
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
 
 serra_data = np.genfromtxt(
     str(Path(__file__).parent) + "/serra_2005/data.csv",
@@ -15,26 +16,22 @@ serra_data = np.genfromtxt(
 )
 
 serra_permeability = Permeability(
-    data_T=1 / serra_data["permx"] * htm.ureg.K,
-    data_y=serra_data["permy"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5,
+    data_T=1 / serra_data["permx"] * u.K,
+    data_y=serra_data["permy"] * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5,
     isotope="H",
     source="serra_hydrogen_2004",
 )
 
 serra_diffusivity = Diffusivity(
-    data_T=1 / serra_data["diffx"] * htm.ureg.K,
-    data_y=serra_data["diffy"] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / serra_data["diffx"] * u.K,
+    data_y=serra_data["diffy"] * u.m**2 * u.s**-1,
     isotope="H",
     source="serra_hydrogen_2004",
 )
 
 serra_solubility = Solubility(
-    data_T=1 / serra_data["solx"] * htm.ureg.K,
-    data_y=serra_data["soly"] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
+    data_T=1 / serra_data["solx"] * u.K,
+    data_y=serra_data["soly"] * u.mol * u.m**-3 * u.Pa**-0.5,
     isotope="H",
     source="serra_hydrogen_2004",
 )
@@ -47,16 +44,16 @@ belonshko_data = np.genfromtxt(
 )
 
 belonshko_diffusivity_solid = Diffusivity(
-    data_T=1 / belonshko_data["alpha_aluminax"] * htm.ureg.K,
-    data_y=belonshko_data["alpha_aluminay"] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / belonshko_data["alpha_aluminax"] * u.K,
+    data_y=belonshko_data["alpha_aluminay"] * u.m**2 * u.s**-1,
     isotope="H",
     source="belonoshko_first-principles_2004",
     note="solid alpha alumina",
 )
 
 belonshko_diffusivity_liquid = Diffusivity(
-    data_T=1 / belonshko_data["liquid_aluminax"] * htm.ureg.K,
-    data_y=belonshko_data["liquid_aluminay"] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / belonshko_data["liquid_aluminax"] * u.K,
+    data_y=belonshko_data["liquid_aluminay"] * u.m**2 * u.s**-1,
     isotope="H",
     source="belonoshko_first-principles_2004",
     note="liquid alumina",
@@ -70,32 +67,32 @@ fowler_data = np.genfromtxt(
 )
 
 fowler_diffusivity_single_crystal = Diffusivity(
-    data_T=1 / fowler_data["single_crystalX"] * htm.ureg.K,
-    data_y=fowler_data["single_crystalY"] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1 / fowler_data["single_crystalX"] * u.K,
+    data_y=fowler_data["single_crystalY"] * u.cm**2 * u.s**-1,
     isotope="T",
     source="fowler_tritium_1977",
     note="single crystal",
 )
 
 fowler_diffusivity_powder = Diffusivity(
-    data_T=1 / fowler_data["powderX"] * htm.ureg.K,
-    data_y=fowler_data["powderY"] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1 / fowler_data["powderX"] * u.K,
+    data_y=fowler_data["powderY"] * u.cm**2 * u.s**-1,
     isotope="T",
     source="fowler_tritium_1977",
     note="powder",
 )
 
 fowler_diffusivity_sintered = Diffusivity(
-    data_T=1 / fowler_data["sinteredX"] * htm.ureg.K,
-    data_y=fowler_data["sinteredY"] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1 / fowler_data["sinteredX"] * u.K,
+    data_y=fowler_data["sinteredY"] * u.cm**2 * u.s**-1,
     isotope="T",
     source="fowler_tritium_1977",
     note="powder",
 )
 
 fowler_diffusivity_doped = Diffusivity(
-    data_T=1 / fowler_data["mgOdopedX"] * htm.ureg.K,
-    data_y=fowler_data["mgOdopedY"] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1 / fowler_data["mgOdopedX"] * u.K,
+    data_y=fowler_data["mgOdopedY"] * u.cm**2 * u.s**-1,
     isotope="T",
     source="fowler_tritium_1977",
     note="MgO doped",

--- a/h_transport_materials/property_database/aluminium/aluminium.py
+++ b/h_transport_materials/property_database/aluminium/aluminium.py
@@ -3,6 +3,7 @@ from h_transport_materials import Diffusivity, Solubility, Permeability
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
 
 # Fig 6 of Young's paper
 data_diffusivity_young = np.genfromtxt(
@@ -11,30 +12,26 @@ data_diffusivity_young = np.genfromtxt(
 )
 
 young_diffusivity = Diffusivity(
-    data_T=1e3 / data_diffusivity_young[:, 0] * htm.ureg.K,
-    data_y=np.exp(data_diffusivity_young[:, 1]) * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1e3 / data_diffusivity_young[:, 0] * u.K,
+    data_y=np.exp(data_diffusivity_young[:, 1]) * u.cm**2 * u.s**-1,
     isotope="H",
     source="young_diffusion_1998",
 )
 
 ransley_solubility = Solubility(
     isotope="H",
-    S_0=2.32e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=39.7 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(723 * htm.ureg.K, 873 * htm.ureg.K),
+    S_0=2.32e-2 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=39.7 * u.kJ * u.mol**-1,
+    range=(723 * u.K, 873 * u.K),
     author="ransley",
     year=1948,
     source="Ransley, C.E., Neufeld, H., 1948. J. Inst. Met. 74, 599–620",
 )
 
 eichenauer_permeability = Permeability(
-    pre_exp=0.38e-5
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5,
-    act_energy=18900 * htm.ureg.K * htm.k_B,
-    range=(630 * htm.ureg.K, 870 * htm.ureg.K),
+    pre_exp=0.38e-5 * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5,
+    act_energy=18900 * u.K * htm.k_B,
+    range=(630 * u.K, 870 * u.K),
     isotope="H",
     source="eichenauer_notitle_1961",
     note="could not find the original paper, found in DOI:10.2172/5277693",
@@ -42,13 +39,9 @@ eichenauer_permeability = Permeability(
 
 # TODO find a way to verify the conversion
 cochran_permeability = Permeability(
-    pre_exp=0.45e-5
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5,
-    act_energy=12360 * htm.ureg.K * htm.k_B,
-    range=(670 * htm.ureg.K, 870 * htm.ureg.K),
+    pre_exp=0.45e-5 * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5,
+    act_energy=12360 * u.K * htm.k_B,
+    range=(670 * u.K, 870 * u.K),
     isotope="H",
     source="cochran_permeability_1961",
     note="the units given in the original paper are odd. This is the conversion found in DOI:10.2172/5277693",
@@ -56,15 +49,11 @@ cochran_permeability = Permeability(
 
 # TODO fit this
 song_permeability = Permeability(
-    pre_exp=1e-6
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=52.5 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=1e-6 * u.mol * u.m**-1 * u.s**-1 * u.MPa**-0.5,
+    act_energy=52.5 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(400, htm.ureg.degC),
-        htm.ureg.Quantity(500, htm.ureg.degC),
+        u.Quantity(400, u.degC),
+        u.Quantity(500, u.degC),
     ),
     isotope="H",
     source="song_study_1997",
@@ -72,47 +61,47 @@ song_permeability = Permeability(
 )
 
 saitoh_diffusivity = Diffusivity(
-    D_0=6.1e-5 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=54.8 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(446 * htm.ureg.K, 681 * htm.ureg.K),
+    D_0=6.1e-5 * u.m**2 * u.s**-1,
+    E_D=54.8 * u.kJ * u.mol**-1,
+    range=(446 * u.K, 681 * u.K),
     isotope="H",
     source="saitoh_hydrogen_1994",
 )
 
 hashimoto_diffusivity = Diffusivity(
-    D_0=0.26 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.62 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=0.26 * u.cm**2 * u.s**-1,
+    E_D=0.62 * u.eV * u.particle**-1,
     range=(
-        htm.ureg.Quantity(300, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(300, u.degC),
+        u.Quantity(400, u.degC),
     ),
     isotope="H",
     source="hashimoto_hydrogen_1983",
 )
 
 ichimura_diffusivity = Diffusivity(
-    D_0=4.58e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=37.0 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.58e-6 * u.m**2 * u.s**-1,
+    E_D=37.0 * u.kJ * u.mol**-1,
     isotope="H",
-    range=(573 * htm.ureg.K, 923 * htm.ureg.K),
+    range=(573 * u.K, 923 * u.K),
     source="ichimura_grain_1991",
     note="columnar grain",
 )
 
 outlaw_diffusivity = Diffusivity(
-    data_T=htm.ureg.Quantity([450, 475, 500, 525, 550, 575, 600, 625], htm.ureg.degC),
+    data_T=u.Quantity([450, 475, 500, 525, 550, 575, 600, 625], u.degC),
     data_y=[3.14e-9, 4.12e-9, 5.30e-9, 6.72e-9, 8.38e-9, 1.03e-8, 1.26e-8, 1.52e-8]
-    * htm.ureg.m**2
-    * htm.ureg.s**-1,
+    * u.m**2
+    * u.s**-1,
     isotope="H",
     source="outlaw_diffusion_1982",
 )
 
 # TODO fit this ourselves (table 2)
 ishikawa_diffusivity = Diffusivity(
-    D_0=9.2e-5 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=55.25 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(285 * htm.ureg.K, 328 * htm.ureg.K),
+    D_0=9.2e-5 * u.m**2 * u.s**-1,
+    E_D=55.25 * u.kJ * u.mol**-1,
+    range=(285 * u.K, 328 * u.K),
     isotope="H",
     source="ishikawa_diffusivity_1986",
 )

--- a/h_transport_materials/property_database/beryllium.py
+++ b/h_transport_materials/property_database/beryllium.py
@@ -1,14 +1,14 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-
+from h_transport_materials.property import RecombinationCoeff
 import numpy as np
 
-from h_transport_materials.property import RecombinationCoeff
+u = htm.ureg
 
 abramov_diffusivity = Diffusivity(
-    D_0=8.0e-9 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=35.1 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(620 * htm.ureg.K, 775 * htm.ureg.K),
+    D_0=8.0e-9 * u.m**2 * u.s**-1,
+    E_D=35.1 * u.kJ * u.mol**-1,
+    range=(620 * u.K, 775 * u.K),
     isotope="D",
     source="abramov_deuterium_1990",
 )
@@ -16,9 +16,9 @@ abramov_diffusivity = Diffusivity(
 
 shapovalov_solubility = Solubility(
     isotope="H",
-    S_0=1.90e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=16.8 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1473 * htm.ureg.K),
+    S_0=1.90e-2 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=16.8 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1473 * u.K),
     author="shapovalov",
     source="Shapovalov, V.I., Dukel'skii, Y.M., 1988. Izv. Akad. Nauk SSR Met. 5, 201–203",
     year=1988,
@@ -27,16 +27,16 @@ shapovalov_solubility = Solubility(
 
 jones_diffusivity = Diffusivity(
     isotope="T",
-    D_0=np.exp(-6.53) * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=965 * htm.ureg.K * htm.k_B,
-    range=(400 * htm.ureg.K, 900 * htm.ureg.K),
+    D_0=np.exp(-6.53) * u.cm**2 * u.s**-1,
+    E_D=965 * u.K * htm.k_B,
+    range=(400 * u.K, 900 * u.K),
     source="jones_hydrogen_1967",
     note="Jones also gives a solubility but the units are weird",
 )
 
 dolan_recombination = RecombinationCoeff(
-    pre_exp=1.46e-29 * htm.ureg.m**4 * htm.ureg.s**-1 * htm.ureg.particle**-1,
-    act_energy=0.214 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=1.46e-29 * u.m**4 * u.s**-1 * u.particle**-1,
+    act_energy=0.214 * u.eV * u.particle**-1,
     source="dolan_assessment_1994",
     isotope="H",
 )

--- a/h_transport_materials/property_database/carbon.py
+++ b/h_transport_materials/property_database/carbon.py
@@ -1,22 +1,22 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 
+u = htm.ureg
 
 causey_diffusivity = Diffusivity(
-    D_0=0.93e-4 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=2.8 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(900 * htm.ureg.K, 1473 * htm.ureg.K),
+    D_0=0.93e-4 * u.m**2 * u.s**-1,
+    E_D=2.8 * u.eV * u.particle**-1,
+    range=(900 * u.K, 1473 * u.K),
     source="causey_interaction_1989",
     isotope="H",
 )
 
 atsumi_diffusivity = Diffusivity(
-    D_0=1.69 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=251 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=1.69 * u.cm**2 * u.s**-1,
+    E_D=251 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(500, htm.ureg.degC),
-        htm.ureg.Quantity(900, htm.ureg.degC),
+        u.Quantity(500, u.degC),
+        u.Quantity(900, u.degC),
     ),
     isotope="D",
     source="atsumi_absorption_1988",
@@ -24,8 +24,8 @@ atsumi_diffusivity = Diffusivity(
 )
 
 atsumi_solubility = Solubility(
-    S_0=1.9e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=-19.2 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=1.9e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=-19.2 * u.kJ * u.mol**-1,
     source="atsumi_absorption_1988",
     isotope="H",
 )

--- a/h_transport_materials/property_database/copper/copper.py
+++ b/h_transport_materials/property_database/copper/copper.py
@@ -1,4 +1,3 @@
-from h_transport_materials import k_B, Rg, avogadro_nb
 import h_transport_materials as htm
 from h_transport_materials.property import (
     Diffusivity,
@@ -9,21 +8,23 @@ from h_transport_materials.property import (
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
+
 COPPER_MOLAR_VOLUME = 7.11e-6  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/copper
 
 # ################# REITER 1996 #############################
 
 reiter_diffusivity_copper = Diffusivity(
-    D_0=6.6e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.39 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(470 * htm.ureg.K, 1200 * htm.ureg.K),
+    D_0=6.6e-7 * u.m**2 * u.s**-1,
+    E_D=0.39 * u.eV * u.particle**-1,
+    range=(470 * u.K, 1200 * u.K),
     source="reiter_compilation_1996",
     isotope="T",
 )
 reiter_solubility_copper = Solubility(
-    S_0=3.14e24 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.57 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(470 * htm.ureg.K, 1200 * htm.ureg.K),
+    S_0=3.14e24 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.57 * u.eV * u.particle**-1,
+    range=(470 * u.K, 1200 * u.K),
     source="reiter_compilation_1996",
     isotope="T",
 )
@@ -32,9 +33,9 @@ reiter_solubility_copper = Solubility(
 
 
 magnusson_diffusivity_copper = Diffusivity(
-    D_0=1.74e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=42000 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(298 * htm.ureg.K, 1273 * htm.ureg.K),
+    D_0=1.74e-6 * u.m**2 * u.s**-1,
+    E_D=42000 * u.J * u.mol**-1,
+    range=(298 * u.K, 1273 * u.K),
     source="magnusson_self-diffusion_2013",
     isotope="H",
 )
@@ -50,8 +51,8 @@ data_diffusivity_katz = np.genfromtxt(
 data_diffusivity_katz_h = data_diffusivity_katz[2:, :2].astype(float)
 
 katz_diffusivity_copper_h = Diffusivity(
-    data_T=1000 / data_diffusivity_katz_h[:, 0] * htm.ureg.K,
-    data_y=data_diffusivity_katz_h[:, 1] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1000 / data_diffusivity_katz_h[:, 0] * u.K,
+    data_y=data_diffusivity_katz_h[:, 1] * u.cm**2 * u.s**-1,
     source=katz_src,
     isotope="H",
 )
@@ -59,8 +60,8 @@ katz_diffusivity_copper_h = Diffusivity(
 
 data_diffusivity_katz_d = data_diffusivity_katz[2:, 2:4].astype(float)
 katz_diffusivity_copper_d = Diffusivity(
-    data_T=1000 / data_diffusivity_katz_d[:, 0] * htm.ureg.K,
-    data_y=data_diffusivity_katz_d[:, 1] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1000 / data_diffusivity_katz_d[:, 0] * u.K,
+    data_y=data_diffusivity_katz_d[:, 1] * u.cm**2 * u.s**-1,
     source=katz_src,
     isotope="D",
 )
@@ -68,43 +69,43 @@ katz_diffusivity_copper_d = Diffusivity(
 
 data_diffusivity_katz_t = data_diffusivity_katz[2:, 4:].astype(float)
 katz_diffusivity_copper_t = Diffusivity(
-    data_T=1000 / data_diffusivity_katz_t[:, 0] * htm.ureg.K,
-    data_y=data_diffusivity_katz_t[:, 1] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=1000 / data_diffusivity_katz_t[:, 0] * u.K,
+    data_y=data_diffusivity_katz_t[:, 1] * u.cm**2 * u.s**-1,
     source=katz_src,
     isotope="T",
 )
 
 # ################# Eichenauer 1957 #############################
 eichenauer_diffusivity_copper_h = Diffusivity(
-    1.1e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.4 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(700 * htm.ureg.K, 920 * htm.ureg.K),
+    1.1e-6 * u.m**2 * u.s**-1,
+    0.4 * u.eV * u.particle**-1,
+    range=(700 * u.K, 920 * u.K),
     source="eichenauer_notitle_1957",
     isotope="H",
 )
 
 eichenauer_solubility_copper_h = Solubility(
-    S_0=4.9e23 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.37 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(700 * htm.ureg.K, 920 * htm.ureg.K),
+    S_0=4.9e23 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.37 * u.eV * u.particle**-1,
+    range=(700 * u.K, 920 * u.K),
     source="eichenauer_notitle_1957",
     isotope="H",
 )
 
 # ################# Perkins 1973 #############################
 perkins_diffusivity_copper_h = Diffusivity(
-    1.06e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.4 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(410 * htm.ureg.K, 710 * htm.ureg.K),
+    1.06e-6 * u.m**2 * u.s**-1,
+    0.4 * u.eV * u.particle**-1,
+    range=(410 * u.K, 710 * u.K),
     source="perkins_permeation_1973",
     isotope="H",
 )
 
 # ################# Tanabe 1987 #############################
 tanabe_diffusivity_copper_d = Diffusivity(
-    6.7e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.24 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(298 * htm.ureg.K, 1070 * htm.ureg.K),
+    6.7e-8 * u.m**2 * u.s**-1,
+    0.24 * u.eV * u.particle**-1,
+    range=(298 * u.K, 1070 * u.K),
     source="tanabe_hydrogen_1987",
     isotope="D",
     note="from Assessment of Database for Interaction of Tritium with ITER Plasma Facing Materials",
@@ -112,26 +113,26 @@ tanabe_diffusivity_copper_d = Diffusivity(
 
 # ################# Eichenauer 1965 #############################
 eichenauer_diffusivity_copper_d = Diffusivity(
-    6.19e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.392 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(703 * htm.ureg.K, 913 * htm.ureg.K),
+    6.19e-7 * u.m**2 * u.s**-1,
+    0.392 * u.eV * u.particle**-1,
+    range=(703 * u.K, 913 * u.K),
     source="eichenauer_notitle_1965",
     isotope="D",
 )
 
 eichenauer_solubility_copper_d = Solubility(
-    S_0=3.19e24 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.41 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(703 * htm.ureg.K, 913 * htm.ureg.K),
+    S_0=3.19e24 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.41 * u.eV * u.particle**-1,
+    range=(703 * u.K, 913 * u.K),
     source="eichenauer_notitle_1965",
     isotope="D",
 )
 
 # ################# Anderl 1990 #############################
 anderl_diffusivity_copper_d = Diffusivity(
-    9.26e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.409 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(638 * htm.ureg.K, 723 * htm.ureg.K),
+    9.26e-7 * u.m**2 * u.s**-1,
+    0.409 * u.eV * u.particle**-1,
+    range=(638 * u.K, 723 * u.K),
     source="anderl_hydrogen_1990",
     isotope="D",
 )
@@ -139,9 +140,9 @@ anderl_diffusivity_copper_d = Diffusivity(
 
 # ################# Anderl 1999 #############################
 anderl_diffusivity_copper_d_1999 = Diffusivity(
-    2.1e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.52 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(700 * htm.ureg.K, 800 * htm.ureg.K),
+    2.1e-6 * u.m**2 * u.s**-1,
+    0.52 * u.eV * u.particle**-1,
+    range=(700 * u.K, 800 * u.K),
     source="anderl_deuterium_1999",
     isotope="D",
 )
@@ -149,36 +150,36 @@ anderl_diffusivity_copper_d_1999 = Diffusivity(
 
 # ################# Sakamoto 1982 #############################
 sakamoto_diffusivity_copper_h = Diffusivity(
-    3.69e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    36820 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(292 * htm.ureg.K, 339 * htm.ureg.K),
+    3.69e-7 * u.m**2 * u.s**-1,
+    36820 * u.J * u.mol**-1,
+    range=(292 * u.K, 339 * u.K),
     source="sakamoto_electrochemical_1982",
     isotope="H",
 )
 
 # ################# Otsuka 2010 #############################
 otsuka_diffusivity_copper_t = Diffusivity(
-    1.11e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.399 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(303 * htm.ureg.K, 353 * htm.ureg.K),
+    1.11e-6 * u.m**2 * u.s**-1,
+    0.399 * u.eV * u.particle**-1,
+    range=(303 * u.K, 353 * u.K),
     source="otsuka_behavior_2010",
     isotope="T",
 )
 
 # ################# Thomas 1967 #############################
 thomas_solubility_copper_h = Solubility(
-    S_0=1.90e24 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.51 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(770 * htm.ureg.K, 1320 * htm.ureg.K),
+    S_0=1.90e24 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.51 * u.eV * u.particle**-1,
+    range=(770 * u.K, 1320 * u.K),
     source="thomas_solubility_1967",
     isotope="H",
 )
 
 # ################# Wampler 1976 #############################
 wampler_solubility_copper_h = Solubility(
-    S_0=1.07e24 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.44 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(770 * htm.ureg.K, 1070 * htm.ureg.K),
+    S_0=1.07e24 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.44 * u.eV * u.particle**-1,
+    range=(770 * u.K, 1070 * u.K),
     source="wampler_precipitation_1976",
     isotope="H",
 )
@@ -201,7 +202,7 @@ data_T_mclellan = (
             594.0,
         ]
     )
-    * htm.ureg.degC
+    * u.degC
 )  # in degC (see Table 1)
 
 data_y_mclellan = (
@@ -225,7 +226,7 @@ data_y_mclellan = (
     * 1e-5
 )  # in at.fr Pa-1/2 see Table 1
 data_y_mclellan *= (
-    1 / COPPER_MOLAR_VOLUME * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5
+    1 / COPPER_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5
 )  # in mol H m-3 Pa-1/2
 
 
@@ -237,20 +238,16 @@ mclellan_solubility = Solubility(
 )
 
 anderl_recombination = RecombinationCoeff(
-    pre_exp=9.1e-18 * htm.ureg.m**4 * htm.ureg.s**-1 * htm.ureg.particle**-1,
-    act_energy=0.99 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=9.1e-18 * u.m**4 * u.s**-1 * u.particle**-1,
+    act_energy=0.99 * u.eV * u.particle**-1,
     isotope="D",
     source="anderl_deuterium_1999",
 )
 
 
 houben_permeability = Permeability(
-    pre_exp=3e-6
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-0.5,
-    act_energy=77 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=3e-6 * u.mol * u.m**-1 * u.s**-1 * u.mbar**-0.5,
+    act_energy=77 * u.kJ * u.mol**-1,
     source="houben_comparison_2022",
     isotope="D",
 )

--- a/h_transport_materials/property_database/cucrzr/cucrzr.py
+++ b/h_transport_materials/property_database/cucrzr/cucrzr.py
@@ -5,14 +5,14 @@ from h_transport_materials.property import (
     Solubility,
     Permeability,
 )
-
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
 
 anderl_recombination = Diffusivity(
-    D_0=2.9e-14 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=1.92 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=2.9e-14 * u.m**2 * u.s**-1,
+    E_D=1.92 * u.eV * u.particle**-1,
     source="anderl_deuterium_1999",
     isotope="D",
 )
@@ -33,8 +33,8 @@ note_serra_diffusivity_h = (
     + "ITER also gives a diffusivity but they adapted it from the wrong equations..."
 )
 serra_diffusivity_h = Diffusivity(
-    data_T=1000 / data_diffusivity_serra_h[:, 0] * htm.ureg.K,
-    data_y=data_diffusivity_serra_h[:, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1000 / data_diffusivity_serra_h[:, 0] * u.K,
+    data_y=data_diffusivity_serra_h[:, 1] * u.m**2 * u.s**-1,
     source="serra_hydrogen_1998",
     isotope="H",
     note=note_serra_diffusivity_h,
@@ -46,8 +46,8 @@ note_serra_diffusivity_d = (
     + "ITER also gives a diffusivity but they adapted it from the wrong equations..."
 )
 serra_diffusivity_d = Diffusivity(
-    data_T=1000 / data_diffusivity_serra_d[:, 0] * htm.ureg.K,
-    data_y=data_diffusivity_serra_d[:, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1000 / data_diffusivity_serra_d[:, 0] * u.K,
+    data_y=data_diffusivity_serra_d[:, 1] * u.m**2 * u.s**-1,
     source="serra_hydrogen_1998",
     isotope="D",
     note=note_serra_diffusivity_d,
@@ -62,93 +62,80 @@ data_solubility_serra_h = data_solubility_serra[2:, :2]
 data_solubility_serra_d = data_solubility_serra[2:, 2:]
 
 serra_solubility_h = Solubility(
-    data_T=1000 / data_solubility_serra_h[:, 0] * htm.ureg.K,
-    data_y=data_solubility_serra_h[:, 1]
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
+    data_T=1000 / data_solubility_serra_h[:, 0] * u.K,
+    data_y=data_solubility_serra_h[:, 1] * u.mol * u.m**-3 * u.Pa**-0.5,
     source="serra_hydrogen_1998",
     isotope="H",
 )
 
 serra_solubility_d = Solubility(
-    data_T=1000 / data_solubility_serra_d[:, 0] * htm.ureg.K,
-    data_y=data_solubility_serra_d[:, 1]
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
+    data_T=1000 / data_solubility_serra_d[:, 0] * u.K,
+    data_y=data_solubility_serra_d[:, 1] * u.mol * u.m**-3 * u.Pa**-0.5,
     source="serra_hydrogen_1998",
     isotope="D",
 )
 # ################# Noh 2016 #############################
 nog_diffusivity_cucrzr_t = Diffusivity(
-    5.05e-4 * htm.ureg.m**2 * htm.ureg.s**-1,
-    0.964 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(573 * htm.ureg.K, 873 * htm.ureg.K),
+    5.05e-4 * u.m**2 * u.s**-1,
+    0.964 * u.eV * u.particle**-1,
+    range=(573 * u.K, 873 * u.K),
     source="noh_hydrogen-isotope_2016",
     isotope="T",
 )
 
 nog_solubility_cucrzr_t_1 = Solubility(
-    S_0=7.83e20 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.0715 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(573 * htm.ureg.K, 873 * htm.ureg.K),
+    S_0=7.83e20 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.0715 * u.eV * u.particle**-1,
+    range=(573 * u.K, 873 * u.K),
     source="noh_hydrogen-isotope_2016",
     isotope="T",
 )
 
 nog_solubility_cucrzr_t_2 = Solubility(
-    S_0=5.42e23 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.4 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(573 * htm.ureg.K, 873 * htm.ureg.K),
+    S_0=5.42e23 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=0.4 * u.eV * u.particle**-1,
+    range=(573 * u.K, 873 * u.K),
     source="noh_hydrogen-isotope_2016",
     isotope="T",
 )
 
 # ################# Anderl 1999 #############################
 anderl_diffusivity_cucrzr_d = Diffusivity(
-    D_0=2.0e-2 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=1.2 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(700 * htm.ureg.K, 800 * htm.ureg.K),
+    D_0=2.0e-2 * u.m**2 * u.s**-1,
+    E_D=1.2 * u.eV * u.particle**-1,
+    range=(700 * u.K, 800 * u.K),
     source="anderl_deuterium_1999",
     isotope="D",
 )
 
 # ################# Penalva 1999 #############################
 penalva_diffusivity_cucrzr_h = Diffusivity(
-    3.55e-5 * htm.ureg.m**2 * htm.ureg.s**-1,
-    65.5e3 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(593 * htm.ureg.K, 773 * htm.ureg.K),
+    3.55e-5 * u.m**2 * u.s**-1,
+    65.5e3 * u.J * u.mol**-1,
+    range=(593 * u.K, 773 * u.K),
     source="penalva_interaction_2012",
     isotope="D",
 )
 
 penalva_solubility_cucrzr_h = Solubility(
-    S_0=6.71e-3 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=8.4e3 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(593 * htm.ureg.K, 773 * htm.ureg.K),
+    S_0=6.71e-3 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=8.4e3 * u.J * u.mol**-1,
+    range=(593 * u.K, 773 * u.K),
     source="penalva_interaction_2012",
     isotope="D",
 )
 
 anderl_recombination = RecombinationCoeff(
-    pre_exp=2.9e-14
-    * htm.ureg.meter**4
-    * htm.ureg.second**-1
-    * htm.ureg.particle**-1,
-    act_energy=1.92 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=2.9e-14 * u.meter**4 * u.second**-1 * u.particle**-1,
+    act_energy=1.92 * u.eV * u.particle**-1,
     isotope="D",
     source="anderl_deuterium_1999",
 )
 
 
 houben_permeability = Permeability(
-    pre_exp=6e-6
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-0.5,
-    act_energy=79 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=6e-6 * u.mol * u.m**-1 * u.s**-1 * u.mbar**-0.5,
+    act_energy=79 * u.kJ * u.mol**-1,
     source="houben_comparison_2022",
     isotope="D",
 )

--- a/h_transport_materials/property_database/eurofer_97/eurofer_97.py
+++ b/h_transport_materials/property_database/eurofer_97/eurofer_97.py
@@ -1,7 +1,6 @@
 import h_transport_materials as htm
 from h_transport_materials.property import Diffusivity, Solubility, Permeability
 from pathlib import Path
-
 import numpy as np
 
 u = htm.ureg

--- a/h_transport_materials/property_database/flibe/flibe.py
+++ b/h_transport_materials/property_database/flibe/flibe.py
@@ -1,32 +1,32 @@
 import h_transport_materials as htm
 from h_transport_materials.property import (
     Diffusivity,
-    RecombinationCoeff,
     Solubility,
     Permeability,
 )
-
 import numpy as np
 from pathlib import Path
 
-BEF2_DENSITY = 1.99 * htm.ureg.g * htm.ureg.cm**-3
-LIF_DENSITY = 2.64 * htm.ureg.g * htm.ureg.cm**-3
+u = htm.ureg
+
+BEF2_DENSITY = 1.99 * u.g * u.cm**-3
+LIF_DENSITY = 2.64 * u.g * u.cm**-3
 
 BEF2_MASS = (
-    47.0089884 * htm.ureg.g * htm.ureg.mol**-1
+    47.0089884 * u.g * u.mol**-1
 )  # https://www.webqc.org/molecular-weight-of-BeF2.html
 LIF_MASS = (
-    25.9394 * htm.ureg.g * htm.ureg.mol**-1
+    25.9394 * u.g * u.mol**-1
 )  # https://www.webqc.org/molecular-weight-of-LiF.html
 
 
 # TODO add experimental points
 calderoni_diffusivity = Diffusivity(
-    D_0=9.3e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=42e3 * htm.ureg.J * htm.ureg.mol**-1,
+    D_0=9.3e-7 * u.m**2 * u.s**-1,
+    E_D=42e3 * u.J * u.mol**-1,
     range=(
-        htm.ureg.Quantity(550, htm.ureg.degC),
-        htm.ureg.Quantity(700, htm.ureg.degC),
+        u.Quantity(550, u.degC),
+        u.Quantity(700, u.degC),
     ),
     source="calderoni_measurement_2008",
     isotope="T",
@@ -34,11 +34,11 @@ calderoni_diffusivity = Diffusivity(
 )
 
 calderoni_solubility = Solubility(
-    S_0=7.9e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
-    E_S=35 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=7.9e-2 * u.mol * u.m**-3 * u.Pa**-1,
+    E_S=35 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(550, htm.ureg.degC),
-        htm.ureg.Quantity(700, htm.ureg.degC),
+        u.Quantity(550, u.degC),
+        u.Quantity(700, u.degC),
     ),
     source="calderoni_measurement_2008",
     isotope="T",
@@ -47,15 +47,15 @@ calderoni_solubility = Solubility(
 
 
 anderl_diffusivity = Diffusivity(
-    data_T=np.array([600, 650]) * htm.ureg.degC,
-    data_y=[8.0e-10, 3.0e-9] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=np.array([600, 650]) * u.degC,
+    data_y=[8.0e-10, 3.0e-9] * u.m**2 * u.s**-1,
     source="anderl_deuteriumtritium_2004",
     isotope="D",
 )
 
 anderl_solubility = Solubility(
-    data_T=np.array([600, 650]) * htm.ureg.degC,
-    data_y=[3.1e-4, 1.0e-4] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
+    data_T=np.array([600, 650]) * u.degC,
+    data_y=[3.1e-4, 1.0e-4] * u.mol * u.m**-3 * u.Pa**-1,
     source="anderl_deuteriumtritium_2004",
     isotope="D",
 )
@@ -68,8 +68,8 @@ data_diffusivity_oishi = np.genfromtxt(
 )
 
 oishi_diffusivity = Diffusivity(
-    data_T=(1 / data_diffusivity_oishi["X"]) * htm.ureg.K,
-    data_y=data_diffusivity_oishi["Y"] * htm.ureg.cm**2 * htm.ureg.s**-1,
+    data_T=(1 / data_diffusivity_oishi["X"]) * u.K,
+    data_y=data_diffusivity_oishi["Y"] * u.cm**2 * u.s**-1,
     source="oishi_tritium_1989",
     isotope="T",
 )
@@ -78,31 +78,31 @@ lif_fraction = 0.66
 flibe_density_field = lif_fraction * LIF_DENSITY + (1 - lif_fraction) * BEF2_DENSITY
 flibe_mass_field = lif_fraction * LIF_MASS + (1 - lif_fraction) * BEF2_MASS
 
-data_solubility_field_h = np.array([3.37e-4, 2.16e-4, 1.51e-4]) * htm.ureg.atm**-1
+data_solubility_field_h = np.array([3.37e-4, 2.16e-4, 1.51e-4]) * u.atm**-1
 data_solubility_field_h *= flibe_density_field
 data_solubility_field_h *= 1 / flibe_mass_field
 
 field_solubility_h = Solubility(
-    data_T=np.array([500, 600, 700]) * htm.ureg.degC,
+    data_T=np.array([500, 600, 700]) * u.degC,
     data_y=data_solubility_field_h,
     source="field_solubilities_1967",
     isotope="H",
     note="HF",
 )
 
-data_solubility_field_d = np.array([2.96e-4, 1.83e-4, 1.25e-4]) * htm.ureg.atm**-1
+data_solubility_field_d = np.array([2.96e-4, 1.83e-4, 1.25e-4]) * u.atm**-1
 data_solubility_field_d *= flibe_density_field
 data_solubility_field_d *= 1 / flibe_mass_field
 
 field_solubility_d = Solubility(
-    data_T=np.array([500, 600, 700]) * htm.ureg.degC,
+    data_T=np.array([500, 600, 700]) * u.degC,
     data_y=data_solubility_field_d,
     source="field_solubilities_1967",
     isotope="D",
     note="DF",
 )
 
-data_maulinauskas_T = np.array([773.0, 873.0, 973.0]) * htm.ureg.K
+data_maulinauskas_T = np.array([773.0, 873.0, 973.0]) * u.K
 
 # see Equation 1 of original paper for conversion from Kc to solubility
 data_maulinauskas_k_c_h = [1.13e-3, 3.17e-3, 3.87e-3]  # Kc adimensionnal
@@ -127,16 +127,16 @@ maulinauskas_solubility_d = Solubility(
 
 
 lam_diffusivity_ions = Diffusivity(
-    data_T=[973.0, 1173.0, 1373.0] * htm.ureg.K,
-    data_y=[3e-9, 7e-9, 11.1e-9] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=[973.0, 1173.0, 1373.0] * u.K,
+    data_y=[3e-9, 7e-9, 11.1e-9] * u.m**2 * u.s**-1,
     isotope="T",
     source="lam_impact_2021",
     note="Calculated for T+",
 )
 
 lam_diffusivity_atoms = Diffusivity(
-    data_T=[973.0, 1173.0, 1373.0] * htm.ureg.K,
-    data_y=[6.3e-9, 16.3e-9, 27.0e-9] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=[973.0, 1173.0, 1373.0] * u.K,
+    data_y=[6.3e-9, 16.3e-9, 27.0e-9] * u.m**2 * u.s**-1,
     isotope="T",
     source="lam_impact_2021",
     note="Calculated for T neutral",
@@ -148,10 +148,8 @@ data_nakamura = np.genfromtxt(
     str(Path(__file__).parent) + "/nakamura_2015/data.csv", delimiter=",", names=True
 )
 
-data_nakamura_diff_flibe_T = 1 / data_nakamura["diff_flibex"] * htm.ureg.K
-data_nakamura_diff_flibe_y = (
-    data_nakamura["diff_flibey"] * htm.ureg.m**2 * htm.ureg.s**-1
-)
+data_nakamura_diff_flibe_T = 1 / data_nakamura["diff_flibex"] * u.K
+data_nakamura_diff_flibe_y = data_nakamura["diff_flibey"] * u.m**2 * u.s**-1
 
 nakamura_diffusivity_h = Diffusivity(
     data_T=data_nakamura_diff_flibe_T,
@@ -160,10 +158,8 @@ nakamura_diffusivity_h = Diffusivity(
     isotope="H",
 )
 
-data_nakamura_sol_flibe_T = 1 / data_nakamura["sol_flibex"] * htm.ureg.K
-data_nakamura_sol_flibe_y = (
-    data_nakamura["sol_flibey"] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1
-)
+data_nakamura_sol_flibe_T = 1 / data_nakamura["sol_flibex"] * u.K
+data_nakamura_sol_flibe_y = data_nakamura["sol_flibey"] * u.mol * u.m**-3 * u.Pa**-1
 nakamura_solubility_h = Solubility(
     data_T=data_nakamura_sol_flibe_T,
     data_y=data_nakamura_sol_flibe_y,
@@ -172,13 +168,9 @@ nakamura_solubility_h = Solubility(
 )
 
 
-data_nakamura_perm_flibe_T = 1 / data_nakamura["perm_flibex"] * htm.ureg.K
+data_nakamura_perm_flibe_T = 1 / data_nakamura["perm_flibex"] * u.K
 data_nakamura_perm_flibe_y = (
-    data_nakamura["perm_flibey"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-1
+    data_nakamura["perm_flibey"] * u.mol * u.m**-1 * u.s**-1 * u.Pa**-1
 )
 nakamura_permeability_h = Permeability(
     data_T=data_nakamura_perm_flibe_T,

--- a/h_transport_materials/property_database/flinak/flinak.py
+++ b/h_transport_materials/property_database/flinak/flinak.py
@@ -3,6 +3,7 @@ from h_transport_materials.property import Diffusivity, Solubility, Permeability
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
 
 # Fukada, 2006
 data_fukada = np.genfromtxt(
@@ -11,8 +12,8 @@ data_fukada = np.genfromtxt(
 )
 
 fukada_diffusivity_h = Diffusivity(
-    data_T=1 / data_fukada[:-1, 0] * htm.ureg.K,
-    data_y=data_fukada[:-1, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / data_fukada[:-1, 0] * u.K,
+    data_y=data_fukada[:-1, 1] * u.m**2 * u.s**-1,
     source="fukada_hydrogen_2006",
     isotope="H",
 )
@@ -24,8 +25,8 @@ data_fukada_S = np.genfromtxt(
 )
 
 fukada_solubility_h = Solubility(
-    data_T=1 / data_fukada_S[:, 0] * htm.ureg.K,
-    data_y=data_fukada_S[:, 1] * htm.ureg.mol * htm.ureg.cm**-3 * htm.ureg.atm**-1,
+    data_T=1 / data_fukada_S[:, 0] * u.K,
+    data_y=data_fukada_S[:, 1] * u.mol * u.cm**-3 * u.atm**-1,
     source="fukada_hydrogen_2006",
     isotope="H",
 )
@@ -35,10 +36,8 @@ data_nakamura = np.genfromtxt(
     str(Path(__file__).parent) + "/nakamura_2015/data.csv", delimiter=",", names=True
 )
 
-data_nakamura_diff_flinak_T = 1 / data_nakamura["diff_flinakx"] * htm.ureg.K
-data_nakamura_diff_flinak_y = (
-    data_nakamura["diff_flinaky"] * htm.ureg.m**2 * htm.ureg.s**-1
-)
+data_nakamura_diff_flinak_T = 1 / data_nakamura["diff_flinakx"] * u.K
+data_nakamura_diff_flinak_y = data_nakamura["diff_flinaky"] * u.m**2 * u.s**-1
 
 nakamura_diffusivity_h = Diffusivity(
     data_T=data_nakamura_diff_flinak_T,
@@ -47,9 +46,9 @@ nakamura_diffusivity_h = Diffusivity(
     isotope="H",
 )
 
-data_nakamura_sol_flinak_T = 1 / data_nakamura["sol_flinakx"] * htm.ureg.K
+data_nakamura_sol_flinak_T = 1 / data_nakamura["sol_flinakx"] * u.K
 data_nakamura_sol_flinak_y = (
-    data_nakamura["sol_flinaky"] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1
+    data_nakamura["sol_flinaky"] * u.mol * u.m**-3 * u.Pa**-1
 )
 nakamura_solubility_h = Solubility(
     data_T=data_nakamura_sol_flinak_T,
@@ -59,13 +58,9 @@ nakamura_solubility_h = Solubility(
 )
 
 
-data_nakamura_perm_flinak_T = 1 / data_nakamura["perm_flinakx"] * htm.ureg.K
+data_nakamura_perm_flinak_T = 1 / data_nakamura["perm_flinakx"] * u.K
 data_nakamura_perm_flinak_y = (
-    data_nakamura["perm_flinaky"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-1
+    data_nakamura["perm_flinaky"] * u.mol * u.m**-1 * u.s**-1 * u.Pa**-1
 )
 nakamura_permeability_h = Permeability(
     data_T=data_nakamura_perm_flinak_T,
@@ -81,8 +76,8 @@ data_lam = np.genfromtxt(
 )
 
 lam_diffusivity_t = Diffusivity(
-    data_T=1 / data_lam[:, 0] * htm.ureg.K,
-    data_y=data_lam[:, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / data_lam[:, 0] * u.K,
+    data_y=data_lam[:, 1] * u.m**2 * u.s**-1,
     source="lam_impact_2021",
     isotope="T",
 )
@@ -93,8 +88,8 @@ data_lam_t_ions = np.genfromtxt(
 )
 
 lam_diffusivity_t_ions = Diffusivity(
-    data_T=1 / data_lam_t_ions[:, 0] * htm.ureg.K,
-    data_y=data_lam_t_ions[:, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / data_lam_t_ions[:, 0] * u.K,
+    data_y=data_lam_t_ions[:, 1] * u.m**2 * u.s**-1,
     source="lam_impact_2021",
     isotope="T",
 )
@@ -106,8 +101,8 @@ data_zeng = np.genfromtxt(
 )
 
 zeng_diffusivity_h_2019 = Diffusivity(
-    data_T=1 / data_zeng[:, 0] * htm.ureg.K,
-    data_y=data_zeng[:, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / data_zeng[:, 0] * u.K,
+    data_y=data_zeng[:, 1] * u.m**2 * u.s**-1,
     source="zeng_behavior_2019",
     isotope="H",
 )
@@ -117,8 +112,8 @@ data_zeng_S = np.genfromtxt(
     delimiter=";",
 )
 zeng_solubility_h_2019 = Solubility(
-    data_T=1 / data_zeng_S[:, 0] * htm.ureg.K,
-    data_y=data_zeng_S[:, 1] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
+    data_T=1 / data_zeng_S[:, 0] * u.K,
+    data_y=data_zeng_S[:, 1] * u.mol * u.m**-3 * u.Pa**-1,
     source="zeng_behavior_2019",
     isotope="H",
 )
@@ -132,8 +127,8 @@ data_zeng_2014 = np.genfromtxt(
 )
 
 zeng_diffusivity_h_2014 = Diffusivity(
-    data_T=data_zeng_2014[:, 0] * htm.ureg.degC,
-    data_y=data_zeng_2014[:, 1] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=data_zeng_2014[:, 0] * u.degC,
+    data_y=data_zeng_2014[:, 1] * u.m**2 * u.s**-1,
     source="zeng_apparatus_2014",
     isotope="H",
 )
@@ -145,8 +140,8 @@ data_zeng_2014_S = np.genfromtxt(
 
 
 zeng_solubility_h_2014 = Solubility(
-    data_T=data_zeng_2014_S[:, 0] * htm.ureg.degC,
-    data_y=data_zeng_2014_S[:, 1] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-1,
+    data_T=data_zeng_2014_S[:, 0] * u.degC,
+    data_y=data_zeng_2014_S[:, 1] * u.mol * u.m**-3 * u.Pa**-1,
     source="zeng_apparatus_2014",
     isotope="H",
 )

--- a/h_transport_materials/property_database/gold.py
+++ b/h_transport_materials/property_database/gold.py
@@ -1,24 +1,25 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 import numpy as np
+
+u = htm.ureg
 
 GOLD_MOLAR_VOLUME = 1.02e-5  # m3/mol https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/gold
 
 # TODO fit it ourselves  https://www.degruyter.com/document/doi/10.1515/zna-1962-0415/html
 eichenauer_diffusivity = Diffusivity(
-    D_0=5.60e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=23.6 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(773 * htm.ureg.K, 1273 * htm.ureg.K),
+    D_0=5.60e-8 * u.m**2 * u.s**-1,
+    E_D=23.6 * u.kJ * u.mol**-1,
+    range=(773 * u.K, 1273 * u.K),
     source="eichenauer_messung_1962",
     isotope="H",
 )
 
 
 shimada_solubility = Solubility(
-    S_0=7.8e1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=99.4 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(773 * htm.ureg.K, 873 * htm.ureg.K),
+    S_0=7.8e1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=99.4 * u.kJ * u.mol**-1,
+    range=(773 * u.K, 873 * u.K),
     source="shimada_608_2020",
     isotope="H",
     note="this was computed from the permeability of Caskey and Derrick and the diffusivity of Eichenauer",
@@ -41,16 +42,14 @@ data_T_mclellan = (
             693.0,
         ]
     )
-    * htm.ureg.degC
+    * u.degC
 )  # degC Table1
 
 data_y_mclellan = (
     np.array([2.86, 2.51, 2.23, 1.93, 1.96, 1.96, 1.66, 1.66, 1.66, 1.30, 1.27, 1.06])
     * 1e-6
 )  # in at.fr. Table 1
-data_y_mclellan *= (
-    1 / GOLD_MOLAR_VOLUME * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5
-)
+data_y_mclellan *= 1 / GOLD_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5
 
 mclellan_solubility = Solubility(
     data_T=data_T_mclellan,

--- a/h_transport_materials/property_database/hastelloy_x.py
+++ b/h_transport_materials/property_database/hastelloy_x.py
@@ -3,51 +3,41 @@ from h_transport_materials import (
     Diffusivity,
     Solubility,
     Permeability,
-    DissociationCoeff,
-    RecombinationCoeff,
 )
 
+u = htm.ureg
+
 kishimoto_diffusivity = Diffusivity(
-    D_0=4.9e-3 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.45 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=4.9e-3 * u.cm**2 * u.s**-1,
+    E_D=0.45 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_solubility = Solubility(
-    S_0=41 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
-    E_S=0.22 * htm.ureg.eV * htm.ureg.particle**-1,
+    S_0=41 * u.ccNTP * u.cm**-3 * u.MPa**-0.5,
+    E_S=0.22 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_permeability = Permeability(
-    pre_exp=7.2e3
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=0.67 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=7.2e3 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.MPa**-0.5,
+    act_energy=0.67 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 
 masui_permeability = Permeability(
-    pre_exp=2290
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.atm**-0.5,
-    act_energy=16000 * htm.ureg.cal * htm.ureg.mol**-1,
+    pre_exp=2290 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.atm**-0.5,
+    act_energy=16000 * u.cal * u.mol**-1,
     range=(
-        htm.ureg.Quantity(800, htm.ureg.degC),
-        htm.ureg.Quantity(1000, htm.ureg.degC),
+        u.Quantity(800, u.degC),
+        u.Quantity(1000, u.degC),
     ),
     isotope="H",
     source="masui_hydrogen_1978",

--- a/h_transport_materials/property_database/inconel_600.py
+++ b/h_transport_materials/property_database/inconel_600.py
@@ -7,180 +7,148 @@ from h_transport_materials import (
     RecombinationCoeff,
 )
 
+u = htm.ureg
+
 kishimoto_diffusivity = Diffusivity(
-    D_0=4.90e-3 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.44 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=4.90e-3 * u.cm**2 * u.s**-1,
+    E_D=0.44 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_solubility = Solubility(
-    S_0=36 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
-    E_S=0.22 * htm.ureg.eV * htm.ureg.particle**-1,
+    S_0=36 * u.ccNTP * u.cm**-3 * u.MPa**-0.5,
+    E_S=0.22 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_permeability = Permeability(
-    pre_exp=6.4e3
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=0.66 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=6.4e3 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.MPa**-0.5,
+    act_energy=0.66 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 rota_diffusivity_h = Diffusivity(
-    D_0=1.7e-2 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=11.9 * htm.ureg.kcal * htm.ureg.mol**-1,
+    D_0=1.7e-2 * u.cm**2 * u.s**-1,
+    E_D=11.9 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_diffusivity_d = Diffusivity(
-    D_0=2.0e-2 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=12.4 * htm.ureg.kcal * htm.ureg.mol**-1,
+    D_0=2.0e-2 * u.cm**2 * u.s**-1,
+    E_D=12.4 * u.kcal * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_permeability_h = Permeability(
-    pre_exp=2.4e15
-    * htm.ureg.particle
-    * htm.ureg.cm**-1
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-0.5,
-    act_energy=13.2 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=2.4e15 * u.particle * u.cm**-1 * u.s**-1 * u.mbar**-0.5,
+    act_energy=13.2 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_permeability_d = Permeability(
-    pre_exp=2.4e15
-    * htm.ureg.particle
-    * htm.ureg.cm**-1
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-0.5,
-    act_energy=13.6 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=2.4e15 * u.particle * u.cm**-1 * u.s**-1 * u.mbar**-0.5,
+    act_energy=13.6 * u.kcal * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_solubility_h = Solubility(
-    S_0=1.4e17 * htm.ureg.particle * htm.ureg.cm**-3 * htm.ureg.mbar**-0.5,
-    E_S=1.3 * htm.ureg.kcal * htm.ureg.mol**-1,
+    S_0=1.4e17 * u.particle * u.cm**-3 * u.mbar**-0.5,
+    E_S=1.3 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_solubility_d = Solubility(
-    S_0=1.2e17 * htm.ureg.particle * htm.ureg.cm**-3 * htm.ureg.mbar**-0.5,
-    E_S=1.2 * htm.ureg.kcal * htm.ureg.mol**-1,
+    S_0=1.2e17 * u.particle * u.cm**-3 * u.mbar**-0.5,
+    E_S=1.2 * u.kcal * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_dissociation_coeff_h = DissociationCoeff(
-    pre_exp=2.6e16
-    * htm.ureg.particle
-    * htm.ureg.cm**-2
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-1,
-    act_energy=12.7 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=2.6e16 * u.particle * u.cm**-2 * u.s**-1 * u.mbar**-1,
+    act_energy=12.7 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_dissociation_coeff_d = DissociationCoeff(
-    pre_exp=2.0e15
-    * htm.ureg.particle
-    * htm.ureg.cm**-2
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-1,
-    act_energy=11.0 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=2.0e15 * u.particle * u.cm**-2 * u.s**-1 * u.mbar**-1,
+    act_energy=11.0 * u.kcal * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_recombination_coeff_h = RecombinationCoeff(
-    pre_exp=1.3e-18
-    * htm.ureg.particle
-    * htm.ureg.cm**4
-    * htm.ureg.particle**-2
-    * htm.ureg.s**-1,
-    act_energy=10.1 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=1.3e-18 * u.particle * u.cm**4 * u.particle**-2 * u.s**-1,
+    act_energy=10.1 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 rota_recombination_coeff_d = RecombinationCoeff(
-    pre_exp=1.4e-19
-    * htm.ureg.particle
-    * htm.ureg.cm**4
-    * htm.ureg.particle**-2
-    * htm.ureg.s**-1,
-    act_energy=8.6 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=1.4e-19 * u.particle * u.cm**4 * u.particle**-2 * u.s**-1,
+    act_energy=8.6 * u.kcal * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(150, htm.ureg.degC),
-        htm.ureg.Quantity(400, htm.ureg.degC),
+        u.Quantity(150, u.degC),
+        u.Quantity(400, u.degC),
     ),
     source="rota_measurements_1982",
 )
 
 masui_permeability = Permeability(
-    pre_exp=2540
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.atm**-0.5,
-    act_energy=15800 * htm.ureg.cal * htm.ureg.mol**-1,
+    pre_exp=2540 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.atm**-0.5,
+    act_energy=15800 * u.cal * u.mol**-1,
     range=(
-        htm.ureg.Quantity(800, htm.ureg.degC),
-        htm.ureg.Quantity(1000, htm.ureg.degC),
+        u.Quantity(800, u.degC),
+        u.Quantity(1000, u.degC),
     ),
     isotope="H",
     source="masui_hydrogen_1978",

--- a/h_transport_materials/property_database/inconel_625.py
+++ b/h_transport_materials/property_database/inconel_625.py
@@ -6,72 +6,65 @@ from h_transport_materials import (
     RecombinationCoeff,
 )
 
+u = htm.ureg
 
 gervasini_diffusivity_H = Diffusivity(
-    D_0=1.75e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=52.6 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=1.75e-6 * u.m**2 * u.s**-1,
+    E_D=52.6 * u.kJ * u.mol**-1,
     isotope="H",
-    range=(650 * htm.ureg.K, 900 * htm.ureg.K),
+    range=(650 * u.K, 900 * u.K),
     source="gervasini_solubility_1984",
 )
 
 gervasini_diffusivity_D = Diffusivity(
-    D_0=2.39e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=57.2 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=2.39e-6 * u.m**2 * u.s**-1,
+    E_D=57.2 * u.kJ * u.mol**-1,
     isotope="D",
-    range=(650 * htm.ureg.K, 900 * htm.ureg.K),
+    range=(650 * u.K, 900 * u.K),
     source="gervasini_solubility_1984",
 )
 
 gervasini_solubility = Solubility(
-    S_0=2.09e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=10.52 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(650 * htm.ureg.K, 900 * htm.ureg.K),
+    S_0=2.09e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=10.52 * u.kJ * u.mol**-1,
+    range=(650 * u.K, 900 * u.K),
     source="gervasini_solubility_1984",
     isotope="H",
     note="the value of the pre-exp factor conversion was taken from Shimada 2020",
 )
 
 perujo_dissociation_coeff_clean = DissociationCoeff(
-    pre_exp=1.6e-3
-    * htm.ureg.mol
-    * htm.ureg.m**-2
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-1,
-    act_energy=48.2 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=1.6e-3 * u.mol * u.m**-2 * u.s**-1 * u.Pa**-1,
+    act_energy=48.2 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="clean surface, stationary",
 )
 
 perujo_recombination_coeff_clean = RecombinationCoeff(
-    pre_exp=2.0e-3 * htm.ureg.mol**-1 * htm.ureg.m**4 * htm.ureg.s**-1,
-    act_energy=11.5 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=2.0e-3 * u.mol**-1 * u.m**4 * u.s**-1,
+    act_energy=11.5 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="clean surface, stationary",
 )
 
 perujo_dissociation_coeff_oxidised = DissociationCoeff(
-    pre_exp=0.26
-    * htm.ureg.mol
-    * htm.ureg.m**-2
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-1,
-    act_energy=111.3 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=0.26 * u.mol * u.m**-2 * u.s**-1 * u.Pa**-1,
+    act_energy=111.3 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="oxidised surface, stationary",
 )
 
 perujo_recombination_coeff_oxidised = RecombinationCoeff(
-    pre_exp=32.0 * htm.ureg.mol**-1 * htm.ureg.m**4 * htm.ureg.s**-1,
-    act_energy=97.0 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=32.0 * u.mol**-1 * u.m**4 * u.s**-1,
+    act_energy=97.0 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="oxidised surface, stationary",
 )

--- a/h_transport_materials/property_database/inconel_750.py
+++ b/h_transport_materials/property_database/inconel_750.py
@@ -3,36 +3,31 @@ from h_transport_materials import (
     Diffusivity,
     Solubility,
     Permeability,
-    DissociationCoeff,
-    RecombinationCoeff,
 )
 
+u = htm.ureg
+
 kishimoto_diffusivity = Diffusivity(
-    D_0=1.6e-2 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.55 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=1.6e-2 * u.cm**2 * u.s**-1,
+    E_D=0.55 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_solubility = Solubility(
-    S_0=14 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
-    E_S=0.12 * htm.ureg.eV * htm.ureg.particle**-1,
+    S_0=14 * u.ccNTP * u.cm**-3 * u.MPa**-0.5,
+    E_S=0.12 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_permeability = Permeability(
-    pre_exp=8.1e3
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=0.67 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=8.1e3 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.MPa**-0.5,
+    act_energy=0.67 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 

--- a/h_transport_materials/property_database/iron.py
+++ b/h_transport_materials/property_database/iron.py
@@ -6,52 +6,50 @@ from h_transport_materials import (
     Permeability,
 )
 
+u = htm.ureg
+
 IRON_MOLAR_VOLUME = 7.09e-6  # m3/mol https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/iron
 
 volkl_diffusivity = Diffusivity(
-    D_0=4.00e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=4.5 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.00e-8 * u.m**2 * u.s**-1,
+    E_D=4.5 * u.kJ * u.mol**-1,
     isotope="H",
-    range=(573 * htm.ureg.K, 1073 * htm.ureg.K),
+    range=(573 * u.K, 1073 * u.K),
     source="volkl_5_1975",
 )
 
 tahara_diffusivity_H = Diffusivity(
-    D_0=4.43e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=5.3 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.43e-8 * u.m**2 * u.s**-1,
+    E_D=5.3 * u.kJ * u.mol**-1,
     isotope="H",
-    range=(500 * htm.ureg.K, 1000 * htm.ureg.K),
+    range=(500 * u.K, 1000 * u.K),
     source="tahara_measurements_1985",
 )
 
 tahara_diffusivity_D = Diffusivity(
-    D_0=4.28e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=6.47 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.28e-8 * u.m**2 * u.s**-1,
+    E_D=6.47 * u.kJ * u.mol**-1,
     isotope="D",
-    range=(500 * htm.ureg.K, 1000 * htm.ureg.K),
+    range=(500 * u.K, 1000 * u.K),
     source="tahara_measurements_1985",
 )
 
 eichenauer_solubility = Solubility(
-    S_0=4.90e-6
-    / IRON_MOLAR_VOLUME
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
-    E_S=24.3 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(473 * htm.ureg.K, 1183 * htm.ureg.K),
+    S_0=4.90e-6 / IRON_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=24.3 * u.kJ * u.mol**-1,
+    range=(473 * u.K, 1183 * u.K),
     isotope="H",
     source="eichenauer_diffusion_1958",
 )
 
 
 nagasaki_recombination_alpha = RecombinationCoeff(
-    pre_exp=1.26e-17 * htm.ureg.cm**4 * htm.ureg.s**-1 * htm.ureg.particle**-1,
-    act_energy=39.2 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=1.26e-17 * u.cm**4 * u.s**-1 * u.particle**-1,
+    act_energy=39.2 * u.kJ * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(600, htm.ureg.degC),
-        htm.ureg.Quantity(900, htm.ureg.degC),
+        u.Quantity(600, u.degC),
+        u.Quantity(900, u.degC),
     ),
     source="nagasaki_ion-driven_1993",
     note="gamma iron, Nagasaki also gives an equivalent form for the recombination coefficient. Here we take the Arrhenius one (Eq. 9)",
@@ -59,12 +57,12 @@ nagasaki_recombination_alpha = RecombinationCoeff(
 
 
 nagasaki_recombination_gamma = RecombinationCoeff(
-    pre_exp=9.93e-20 * htm.ureg.cm**4 * htm.ureg.s**-1 * htm.ureg.particle**-1,
-    act_energy=78.8 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=9.93e-20 * u.cm**4 * u.s**-1 * u.particle**-1,
+    act_energy=78.8 * u.kJ * u.mol**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(900, htm.ureg.degC),
-        htm.ureg.Quantity(1050, htm.ureg.degC),
+        u.Quantity(900, u.degC),
+        u.Quantity(1050, u.degC),
     ),
     source="nagasaki_ion-driven_1993",
     note="gamma iron, Nagasaki also gives an equivalent form for the recombination coefficient. Here we take the Arrhenius one (Eq. 9)",
@@ -72,27 +70,22 @@ nagasaki_recombination_gamma = RecombinationCoeff(
 
 # TODO fit this ourselves
 addach_diffusivity = Diffusivity(
-    D_0=1.02e-6 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=19.6 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=1.02e-6 * u.cm**2 * u.s**-1,
+    E_D=19.6 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(25, htm.ureg.degC),
-        htm.ureg.Quantity(45, htm.ureg.degC),
+        u.Quantity(25, u.degC),
+        u.Quantity(45, u.degC),
     ),
     isotope="H",
     source="addach_hydrogen_2005",
 )
 
 masui_permeability_alpha = Permeability(
-    pre_exp=113
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.atm**-0.5,
-    act_energy=8190 * htm.ureg.cal * htm.ureg.mol**-1,
+    pre_exp=113 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.atm**-0.5,
+    act_energy=8190 * u.cal * u.mol**-1,
     range=(
-        htm.ureg.Quantity(200, htm.ureg.degC),
-        htm.ureg.Quantity(850, htm.ureg.degC),
+        u.Quantity(200, u.degC),
+        u.Quantity(850, u.degC),
     ),
     isotope="H",
     source="masui_hydrogen_1978",
@@ -100,16 +93,11 @@ masui_permeability_alpha = Permeability(
 )
 
 masui_permeability_gamma = Permeability(
-    pre_exp=1630
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.atm**-0.5,
-    act_energy=16900 * htm.ureg.cal * htm.ureg.mol**-1,
+    pre_exp=1630 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.atm**-0.5,
+    act_energy=16900 * u.cal * u.mol**-1,
     range=(
-        htm.ureg.Quantity(930, htm.ureg.degC),
-        htm.ureg.Quantity(1000, htm.ureg.degC),
+        u.Quantity(930, u.degC),
+        u.Quantity(1000, u.degC),
     ),
     isotope="H",
     source="masui_hydrogen_1978",

--- a/h_transport_materials/property_database/lithium/lithium.py
+++ b/h_transport_materials/property_database/lithium/lithium.py
@@ -1,13 +1,13 @@
 from h_transport_materials.property import Diffusivity, Solubility
 import h_transport_materials as htm
-from h_transport_materials import k_B, Rg, avogadro_nb
-
+from h_transport_materials import k_B
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
 
 LITHIUM_MOLAR_VOLUME = (
-    1.3e-5 * htm.ureg.m**3 * htm.ureg.mol**-1
+    1.3e-5 * u.m**3 * u.mol**-1
 )  # m3/mol ref https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/lithium
 
 
@@ -18,21 +18,21 @@ alire_diffusivity_data = np.genfromtxt(
 
 
 alire_diffusivity = Diffusivity(
-    data_T=(1 / alire_diffusivity_data[:, 0]) * htm.ureg.K,
-    data_y=alire_diffusivity_data[:, 1] * htm.ureg.cm**2 * htm.ureg.s**-1,
-    range=(898 * htm.ureg.K, 1178 * htm.ureg.K),
+    data_T=(1 / alire_diffusivity_data[:, 0]) * u.K,
+    data_y=alire_diffusivity_data[:, 1] * u.cm**2 * u.s**-1,
+    range=(898 * u.K, 1178 * u.K),
     isotope="H",
     source="alire_transport_1976",
     note="in Shimada 2020, there is an error in Table 1 Lithium (lq.) line E_D column it should be 105.0 kJ/mol",
 )
 
 veleckis_solubility = Solubility(
-    S_0=np.exp(-6.498) / LITHIUM_MOLAR_VOLUME * htm.ureg.atm**-0.5,
+    S_0=np.exp(-6.498) / LITHIUM_MOLAR_VOLUME * u.atm**-0.5,
     # S_0=1.75e-1 * avogadro_nb,
-    E_S=-6182 * htm.ureg.K * k_B,
+    E_S=-6182 * u.K * k_B,
     range=(
-        htm.ureg.Quantity(710, htm.ureg.degC),
-        htm.ureg.Quantity(903, htm.ureg.degC),
+        u.Quantity(710, u.degC),
+        u.Quantity(903, u.degC),
     ),
     source="veleckis_lithium-lithium_1974",
     isotope="H",
@@ -40,15 +40,15 @@ veleckis_solubility = Solubility(
 )
 
 
-smith_sol_data_y_h = htm.ureg.Quantity(
+smith_sol_data_y_h = u.Quantity(
     [31.0, 42.0, 56.0, 74.0, 93.0, 110.0, 137.0],
-    htm.ureg.torr**0.5 * htm.ureg.mol / htm.ureg.mol,
+    u.torr**0.5 * u.mol / u.mol,
 )
 smith_sol_data_y_h **= -1
 smith_sol_data_y_h *= 1 / LITHIUM_MOLAR_VOLUME
 
 smith_solubility_h = Solubility(
-    data_T=htm.ureg.Quantity([700, 750, 800, 850, 900, 950, 1000], htm.ureg.degC),
+    data_T=u.Quantity([700, 750, 800, 850, 900, 950, 1000], u.degC),
     data_y=smith_sol_data_y_h,
     isotope="H",
     source="smith_solubility_1979",
@@ -56,15 +56,15 @@ smith_solubility_h = Solubility(
 )
 
 
-smith_sol_data_y_d = htm.ureg.Quantity(
+smith_sol_data_y_d = u.Quantity(
     [41.0, 54.0, 76.0, 88.0, 112.0, 134.0, 160.0],
-    htm.ureg.torr**0.5 * htm.ureg.mol / htm.ureg.mol,
+    u.torr**0.5 * u.mol / u.mol,
 )
 smith_sol_data_y_d **= -1
 smith_sol_data_y_d *= 1 / LITHIUM_MOLAR_VOLUME
 
 smith_solubility_d = Solubility(
-    data_T=htm.ureg.Quantity([700, 750, 800, 850, 900, 950, 1000], htm.ureg.degC),
+    data_T=u.Quantity([700, 750, 800, 850, 900, 950, 1000], u.degC),
     data_y=smith_sol_data_y_d,
     isotope="D",
     source="smith_solubility_1979",
@@ -72,15 +72,15 @@ smith_solubility_d = Solubility(
 )
 
 
-smith_sol_data_y_t = htm.ureg.Quantity(
+smith_sol_data_y_t = u.Quantity(
     [57.0, 71.0, 89.0, 108.0, 130.0, 160.0, 190.0],
-    htm.ureg.torr**0.5 * htm.ureg.mol / htm.ureg.mol,
+    u.torr**0.5 * u.mol / u.mol,
 )
 smith_sol_data_y_t **= -1
 smith_sol_data_y_t *= 1 / LITHIUM_MOLAR_VOLUME
 
 smith_solubility_t = Solubility(
-    data_T=htm.ureg.Quantity([700, 750, 800, 850, 900, 950, 1000], htm.ureg.degC),
+    data_T=u.Quantity([700, 750, 800, 850, 900, 950, 1000], u.degC),
     data_y=smith_sol_data_y_t,
     isotope="T",
     source="smith_solubility_1979",

--- a/h_transport_materials/property_database/molybdenum.py
+++ b/h_transport_materials/property_database/molybdenum.py
@@ -1,55 +1,49 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility, Permeability
-
 import numpy as np
 
+u = htm.ureg
+
 tanabe_diffusivity = Diffusivity(
-    D_0=4.00e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=22.3 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.00e-8 * u.m**2 * u.s**-1,
+    E_D=22.3 * u.kJ * u.mol**-1,
     isotope="H",
-    range=(500 * htm.ureg.K, 1100 * htm.ureg.K),
+    range=(500 * u.K, 1100 * u.K),
     source="tanabe_hydrogen_1992",
 )
 
 katsuta_diffusivity = Diffusivity(
-    D_0=np.exp(-17.547) * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=1.266e3 * htm.ureg.K * htm.k_B,
+    D_0=np.exp(-17.547) * u.m**2 * u.s**-1,
+    E_D=1.266e3 * u.K * htm.k_B,
     isotope="H",
-    range=(833 * htm.ureg.K, 1193 * htm.ureg.K),
+    range=(833 * u.K, 1193 * u.K),
     source="katsuta_diffusivity_1982",
 )
 
 tanabe_solubility = Solubility(
-    S_0=3.3 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=37.4 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(500 * htm.ureg.K, 1100 * htm.ureg.K),
+    S_0=3.3 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=37.4 * u.kJ * u.mol**-1,
+    range=(500 * u.K, 1100 * u.K),
     isotope="H",
     source="tanabe_hydrogen_1992",
 )
 
 katsuta_solubility = Solubility(
-    S_0=np.exp(8.703) * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=7.863e3 * htm.ureg.K * htm.k_B,
+    S_0=np.exp(8.703) * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=7.863e3 * u.K * htm.k_B,
     isotope="H",
     source="katsuta_diffusivity_1982",
 )
 
 
-frauenfelder_p_0 = (
-    7.1e-4
-    * htm.ureg.torr
-    * htm.ureg.liter
-    * htm.ureg.cm**-1
-    * htm.ureg.s**-1
-    * htm.ureg.torr**-0.5
-)
+frauenfelder_p_0 = 7.1e-4 * u.torr * u.liter * u.cm**-1 * u.s**-1 * u.torr**-0.5
 frauenfelder_permeability = Permeability(
-    pre_exp=frauenfelder_p_0 / (htm.Rg * 300 * htm.ureg.K),
-    act_energy=21.5 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=frauenfelder_p_0 / (htm.Rg * 300 * u.K),
+    act_energy=21.5 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(1050, htm.ureg.degC),
-        htm.ureg.Quantity(2400, htm.ureg.degC),
+        u.Quantity(1050, u.degC),
+        u.Quantity(2400, u.degC),
     ),
     source="frauenfelder_permeation_1968",
 )

--- a/h_transport_materials/property_database/nickel.py
+++ b/h_transport_materials/property_database/nickel.py
@@ -6,8 +6,9 @@ from h_transport_materials import (
     DissociationCoeff,
 )
 
-NI_MOLAR_VOLUME = 6.59e-6  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/nickel
 u = htm.ureg
+
+NI_MOLAR_VOLUME = 6.59e-6  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/nickel
 
 volkl_diffusivity = Diffusivity(
     D_0=6.87e-7 * u.m**2 * u.s**-1,

--- a/h_transport_materials/property_database/nimonic_80A.py
+++ b/h_transport_materials/property_database/nimonic_80A.py
@@ -3,36 +3,31 @@ from h_transport_materials import (
     Diffusivity,
     Solubility,
     Permeability,
-    DissociationCoeff,
-    RecombinationCoeff,
 )
 
+u = htm.ureg
+
 kishimoto_diffusivity = Diffusivity(
-    D_0=1.4e-2 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.55 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=1.4e-2 * u.cm**2 * u.s**-1,
+    E_D=0.55 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_solubility = Solubility(
-    S_0=17 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
-    E_S=0.12 * htm.ureg.eV * htm.ureg.particle**-1,
+    S_0=17 * u.ccNTP * u.cm**-3 * u.MPa**-0.5,
+    E_S=0.12 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_permeability = Permeability(
-    pre_exp=8.1e3
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=0.67 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=8.1e3 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.MPa**-0.5,
+    act_energy=0.67 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 

--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -1,38 +1,36 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
 
+u = htm.ureg
+
 NIOBIUM_MOLAR_VOLUME = 1.08e-8  # m3/mol https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/niobium
 
 volkl_diffusivity = Diffusivity(
-    D_0=5.00e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=10.2 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(273 * htm.ureg.K, 773 * htm.ureg.K),
+    D_0=5.00e-8 * u.m**2 * u.s**-1,
+    E_D=10.2 * u.kJ * u.mol**-1,
+    range=(273 * u.K, 773 * u.K),
     source="volkl_5_1975",
     isotope="H",
 )
 
 schober_diffusivity = Diffusivity(
-    D_0=4.4e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=12.8 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.4e-8 * u.m**2 * u.s**-1,
+    E_D=12.8 * u.kJ * u.mol**-1,
     source="schober_h_1990",
     isotope="H",
 )
 
 veleckis_solubility = Solubility(
-    S_0=1.26e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=-35.3 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(625 * htm.ureg.K, 944 * htm.ureg.K),
+    S_0=1.26e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=-35.3 * u.kJ * u.mol**-1,
+    range=(625 * u.K, 944 * u.K),
     source="veleckis_thermodynamic_1969",
     isotope="H",
 )
 
 reiter_solubility = Solubility(
-    S_0=3.6e-6
-    / NIOBIUM_MOLAR_VOLUME
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
-    E_S=-33.9 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=3.6e-6 / NIOBIUM_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=-33.9 * u.kJ * u.mol**-1,
     source="reiter_compilation_1996",
     isotope="H",
 )

--- a/h_transport_materials/property_database/palladium.py
+++ b/h_transport_materials/property_database/palladium.py
@@ -1,23 +1,22 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
-
 import numpy as np
 
+u = htm.ureg
+
 PALLADIUM_MOLAR_VOLUME = (
-    8.85e-6 * htm.ureg.m**3 * htm.ureg.mol**-1
+    8.85e-6 * u.m**3 * u.mol**-1
 )  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/palladium
 PALLADIUM_VOLUMIC_DENSITY = (
     8.32e-8
-    * htm.ureg.m**3
-    * htm.ureg.g
-    ** -1  # m3/g  https://www.aqua-calc.com/calculate/weight-to-volume/palladium
+    * u.m**3
+    * u.g**-1  # m3/g  https://www.aqua-calc.com/calculate/weight-to-volume/palladium
 )
 
 volkl_diffusivity = Diffusivity(
-    D_0=2.90e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=22.2 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(223 * htm.ureg.K, 873 * htm.ureg.K),
+    D_0=2.90e-7 * u.m**2 * u.s**-1,
+    E_D=22.2 * u.kJ * u.mol**-1,
+    range=(223 * u.K, 873 * u.K),
     source="volkl_5_1975",
     isotope="H",
 )
@@ -80,16 +79,16 @@ favreau_data_y = (
             0.1039,
         ]
     )
-    * htm.ureg.ccSTP
-    * htm.ureg.g**-1
-    * htm.ureg.cmHg**-0.5
+    * u.ccSTP
+    * u.g**-1
+    * u.cmHg**-0.5
 )  # in cc STP per gram of palladium  cmHg^-1.2
 
 # favreau_data_y = c.ccSTP_to_mol(favreau_data_y)  # mol T per gram of Pd  cmHg-1.2
 favreau_data_y *= 1 / PALLADIUM_VOLUMIC_DENSITY  # mol T m-3  cmHg-1.2
 
 favreau_solubility_t = Solubility(
-    data_T=favreau_data_T * htm.ureg.degC,
+    data_T=favreau_data_T * u.degC,
     data_y=favreau_data_y,
     # S_0=4.45e-1 * htm.avogadro_nb,
     # E_S=c.kJ_per_mol_to_eV(-8.4),
@@ -240,16 +239,16 @@ favreau_data_y_h = (
             0.1767,
         ]
     )
-    * htm.ureg.ccSTP
-    * htm.ureg.g**-1
-    * htm.ureg.cmHg**-0.5
+    * u.ccSTP
+    * u.g**-1
+    * u.cmHg**-0.5
 )  # in cc STP per gram of palladium  cmHg^-1.2
 
 
 favreau_data_y_h *= 1 / PALLADIUM_VOLUMIC_DENSITY  # mol T m-3  cmHg-1.2
 
 favreau_solubility_h = Solubility(
-    data_T=favreau_data_T_h * htm.ureg.degC,
+    data_T=favreau_data_T_h * u.degC,
     data_y=favreau_data_y_h,
     source="favreau_solubility_1954",
     isotope="H",

--- a/h_transport_materials/property_database/rafm_steel.py
+++ b/h_transport_materials/property_database/rafm_steel.py
@@ -1,31 +1,32 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
 
+u = htm.ureg
 
 causey_diffusivity = Diffusivity(
-    D_0=1.00e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=13.2 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(300 * htm.ureg.K, 973 * htm.ureg.K),
+    D_0=1.00e-7 * u.m**2 * u.s**-1,
+    E_D=13.2 * u.kJ * u.mol**-1,
+    range=(300 * u.K, 973 * u.K),
     source="causey_416_2012",
     isotope="H",
     note="value obtained from a average estimate from several authors",
 )
 
 causey_solubility = Solubility(
-    S_0=4.40e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=28.6 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(300 * htm.ureg.K, 973 * htm.ureg.K),
+    S_0=4.40e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=28.6 * u.kJ * u.mol**-1,
+    range=(300 * u.K, 973 * u.K),
     isotope="H",
     source="causey_416_2012",
     note="value obtained from a average estimate from several authors",
 )
 
 forcey_diffusivity = htm.Diffusivity(
-    D_0=7.17e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=13490 * htm.ureg.J * htm.ureg.mol**-1,
+    D_0=7.17e-8 * u.m**2 * u.s**-1,
+    E_D=13490 * u.J * u.mol**-1,
     range=(
-        htm.ureg.Quantity(250, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(250, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="forcey_hydrogen_1988",
@@ -33,14 +34,11 @@ forcey_diffusivity = htm.Diffusivity(
 )
 
 forcey_solubility = htm.Solubility(
-    S_0=1.29
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,  # NOTE: typo in Eq. 16
-    E_S=29620 * htm.ureg.J * htm.ureg.mol**-1,
+    S_0=1.29 * u.mol * u.m**-3 * u.Pa**-0.5,  # NOTE: typo in Eq. 16
+    E_S=29620 * u.J * u.mol**-1,
     range=(
-        htm.ureg.Quantity(250, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(250, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="forcey_hydrogen_1988",
@@ -49,16 +47,16 @@ forcey_solubility = htm.Solubility(
 
 # TODO fit this ourselves
 serra_diffusivity_f82h = htm.Diffusivity(
-    D_0=1.07e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=13950 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(373 * htm.ureg.K, 743 * htm.ureg.K),
+    D_0=1.07e-7 * u.m**2 * u.s**-1,
+    E_D=13950 * u.J * u.mol**-1,
+    range=(373 * u.K, 743 * u.K),
     source="serra_influence_1997",
     isotope="D",
 )
 serra_solubility_f82h = htm.Solubility(
-    S_0=0.377 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=26880 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(373 * htm.ureg.K, 743 * htm.ureg.K),
+    S_0=0.377 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=26880 * u.J * u.mol**-1,
+    range=(373 * u.K, 743 * u.K),
     source="serra_influence_1997",
     isotope="D",
     note="F82H",
@@ -67,17 +65,17 @@ serra_solubility_f82h = htm.Solubility(
 
 # TODO fit this ourselves
 serra_diffusivity_batman = htm.Diffusivity(
-    D_0=1.9e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=15190 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(373 * htm.ureg.K, 743 * htm.ureg.K),
+    D_0=1.9e-7 * u.m**2 * u.s**-1,
+    E_D=15190 * u.J * u.mol**-1,
+    range=(373 * u.K, 743 * u.K),
     source="serra_influence_1997",
     isotope="D",
     note="Batman steel",
 )
 serra_solubility_batman = htm.Solubility(
-    S_0=0.198 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=24703 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(373 * htm.ureg.K, 743 * htm.ureg.K),
+    S_0=0.198 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=24703 * u.J * u.mol**-1,
+    range=(373 * u.K, 743 * u.K),
     source="serra_influence_1997",
     isotope="D",
     note="Batman steel",
@@ -85,18 +83,18 @@ serra_solubility_batman = htm.Solubility(
 
 # TODO: try and fit this ourselves (Figures 10 and 11)
 pisarev_diffusivity = htm.Diffusivity(
-    D_0=8.6e-4 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.075 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(573 * htm.ureg.K, 873 * htm.ureg.K),
+    D_0=8.6e-4 * u.cm**2 * u.s**-1,
+    E_D=0.075 * u.eV * u.particle**-1,
+    range=(573 * u.K, 873 * u.K),
     isotope="D",
     source="pisarev_surface_2001",
     note="F82H",
 )
 
 pisarev_solubility = htm.Solubility(
-    S_0=2.0e18 * htm.ureg.particle * htm.ureg.cm**-3 * htm.ureg.Pa**-0.5,
-    E_S=0.343 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(573 * htm.ureg.K, 873 * htm.ureg.K),
+    S_0=2.0e18 * u.particle * u.cm**-3 * u.Pa**-0.5,
+    E_S=0.343 * u.eV * u.particle**-1,
+    range=(573 * u.K, 873 * u.K),
     isotope="D",
     source="pisarev_surface_2001",
 )
@@ -104,52 +102,52 @@ pisarev_solubility = htm.Solubility(
 
 # TODO: fit this ourselves from the paper
 esteban_diffusivity_h = htm.Diffusivity(
-    D_0=5.489e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=10574 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(423 * htm.ureg.K, 892 * htm.ureg.K),
+    D_0=5.489e-8 * u.m**2 * u.s**-1,
+    E_D=10574 * u.J * u.mol**-1,
+    range=(423 * u.K, 892 * u.K),
     isotope="H",
     source="esteban_tritium_2000",
     note="OPTIFER-IVb",
 )
 
 esteban_solubility_h = htm.Solubility(
-    S_0=0.328 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=29005 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(423 * htm.ureg.K, 892 * htm.ureg.K),
+    S_0=0.328 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=29005 * u.J * u.mol**-1,
+    range=(423 * u.K, 892 * u.K),
     isotope="H",
     source="esteban_tritium_2000",
 )
 
 esteban_diffusivity_d = htm.Diffusivity(
-    D_0=4.613e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=11321 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(423 * htm.ureg.K, 892 * htm.ureg.K),
+    D_0=4.613e-8 * u.m**2 * u.s**-1,
+    E_D=11321 * u.J * u.mol**-1,
+    range=(423 * u.K, 892 * u.K),
     isotope="D",
     source="esteban_tritium_2000",
 )
 
 esteban_solubility_d = htm.Solubility(
-    S_0=0.325 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=28955 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(423 * htm.ureg.K, 892 * htm.ureg.K),
+    S_0=0.325 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=28955 * u.J * u.mol**-1,
+    range=(423 * u.K, 892 * u.K),
     isotope="D",
     source="esteban_tritium_2000",
 )
 
 
 esteban_diffusivity_t = htm.Diffusivity(
-    D_0=4.166e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=12027 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(423 * htm.ureg.K, 892 * htm.ureg.K),
+    D_0=4.166e-8 * u.m**2 * u.s**-1,
+    E_D=12027 * u.J * u.mol**-1,
+    range=(423 * u.K, 892 * u.K),
     isotope="T",
     source="esteban_tritium_2000",
     note="extrapolation",
 )
 
 esteban_solubility_t = htm.Solubility(
-    S_0=0.271 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=27905 * htm.ureg.J * htm.ureg.mol**-1,
-    range=(423 * htm.ureg.K, 892 * htm.ureg.K),
+    S_0=0.271 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=27905 * u.J * u.mol**-1,
+    range=(423 * u.K, 892 * u.K),
     isotope="T",
     source="esteban_tritium_2000",
     note="extrapolation",
@@ -159,18 +157,18 @@ esteban_solubility_t = htm.Solubility(
 # TODO: Dolinski gives permeability and diffusivities, should we compute solubility ourselves?
 
 dolinski_diffusivity_d = htm.Diffusivity(
-    D_0=6.6e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=29 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(520 * htm.ureg.K, 900 * htm.ureg.K),
+    D_0=6.6e-7 * u.m**2 * u.s**-1,
+    E_D=29 * u.kJ * u.mol**-1,
+    range=(520 * u.K, 900 * u.K),
     isotope="D",
     source="dolinski_heavy_2000",
     note="DIN 1.4914 (MANET) steel",
 )
 
 dolinski_diffusivity_t = htm.Diffusivity(
-    D_0=5.0e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=29 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(520 * htm.ureg.K, 900 * htm.ureg.K),
+    D_0=5.0e-7 * u.m**2 * u.s**-1,
+    E_D=29 * u.kJ * u.mol**-1,
+    range=(520 * u.K, 900 * u.K),
     isotope="T",
     source="dolinski_heavy_2000",
     note="DIN 1.4914 (MANET) steel",
@@ -179,11 +177,11 @@ dolinski_diffusivity_t = htm.Diffusivity(
 
 # TODO: fit this ourselves Figures 2, 3
 kulsartov_diffusivity_h = htm.Diffusivity(
-    D_0=2.8e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=8.0 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=2.8e-8 * u.m**2 * u.s**-1,
+    E_D=8.0 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(400, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(400, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="kulsartov_investigation_2006",
@@ -191,11 +189,11 @@ kulsartov_diffusivity_h = htm.Diffusivity(
 )
 
 kulsartov_solubility_h = htm.Solubility(
-    S_0=7.7 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=33 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=7.7 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=33 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(400, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(400, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="kulsartov_investigation_2006",
@@ -203,21 +201,21 @@ kulsartov_solubility_h = htm.Solubility(
 
 
 kulsartov_diffusivity_d = htm.Diffusivity(
-    D_0=2.3e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=7.8 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=2.3e-8 * u.m**2 * u.s**-1,
+    E_D=7.8 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(400, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(400, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="D",
     source="kulsartov_investigation_2006",
 )
 kulsartov_solubility_d = htm.Solubility(
-    S_0=7.4 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=36 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=7.4 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=36 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(400, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(400, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="D",
     source="kulsartov_investigation_2006",

--- a/h_transport_materials/property_database/series_300_steel.py
+++ b/h_transport_materials/property_database/series_300_steel.py
@@ -1,21 +1,21 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 
+u = htm.ureg
 
 perng_diffusivity = Diffusivity(
-    D_0=2.01e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=49.3 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(373 * htm.ureg.K, 623 * htm.ureg.K),
+    D_0=2.01e-7 * u.m**2 * u.s**-1,
+    E_D=49.3 * u.kJ * u.mol**-1,
+    range=(373 * u.K, 623 * u.K),
     source="perng_effects_1986",
     isotope="H",
     note="best fit for 4 different austenitic steels",
 )
 
 perng_solubility = Solubility(
-    range=(373 * htm.ureg.K, 623 * htm.ureg.K),
-    S_0=2.70e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=6.9 * htm.ureg.kJ * htm.ureg.mol**-1,
+    range=(373 * u.K, 623 * u.K),
+    S_0=2.70e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=6.9 * u.kJ * u.mol**-1,
     isotope="H",
     source="perng_effects_1986",
 )

--- a/h_transport_materials/property_database/silver.py
+++ b/h_transport_materials/property_database/silver.py
@@ -2,12 +2,14 @@ import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
 import numpy as np
 
+u = htm.ureg
+
 SILVER_MOLAR_VOLUME = 1.03e-5  # m3/mol  https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/silver
 
 katsuta_diffusivity = Diffusivity(
-    D_0=8.55e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=3.62e3 * htm.ureg.K * htm.k_B,
-    range=(947 * htm.ureg.K, 1123 * htm.ureg.K),
+    D_0=8.55e-7 * u.m**2 * u.s**-1,
+    E_D=3.62e3 * u.K * htm.k_B,
+    range=(947 * u.K, 1123 * u.K),
     source="katsuta_diffusivity_1979",
     isotope="H",
 )
@@ -24,8 +26,8 @@ data_y_mclellan *= 1 / SILVER_MOLAR_VOLUME  # in m-3 Pa-1/2
 
 
 mclellan_solubility = Solubility(
-    data_T=data_T_mclellan * htm.ureg.degC,
-    data_y=data_y_mclellan * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
+    data_T=data_T_mclellan * u.degC,
+    data_y=data_y_mclellan * u.mol * u.m**-3 * u.Pa**-0.5,
     source="mclellan_solid_1973",
     isotope="H",
     note="there is likely a mistake in Shimada's 2020 Review",

--- a/h_transport_materials/property_database/steel_316L/steel_316L.py
+++ b/h_transport_materials/property_database/steel_316L/steel_316L.py
@@ -10,171 +10,144 @@ from h_transport_materials.property_database.iron import IRON_MOLAR_VOLUME
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
+
 reiter_diffusivity = Diffusivity(
-    D_0=3.70e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=51.9 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(500 * htm.ureg.K, 1200 * htm.ureg.K),
+    D_0=3.70e-7 * u.m**2 * u.s**-1,
+    E_D=51.9 * u.kJ * u.mol**-1,
+    range=(500 * u.K, 1200 * u.K),
     isotope="H",
     source="reiter_compilation_1996",
     note="this is an average of 10 papers on diffusivity from Reiter compilation review",
 )
 
 reiter_solubility = Solubility(
-    S_0=5.8e-6
-    / IRON_MOLAR_VOLUME
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
-    E_S=13.1 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(500 * htm.ureg.K, 1200 * htm.ureg.K),
+    S_0=5.8e-6 / IRON_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=13.1 * u.kJ * u.mol**-1,
+    range=(500 * u.K, 1200 * u.K),
     isotope="H",
     source="reiter_compilation_1996",
     note="this is an average of 5 papers on diffusivity from Reiter compilation review",
 )
 
 houben_permeability = Permeability(
-    pre_exp=8e-7
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.mbar**-0.5,
-    act_energy=58 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=8e-7 * u.mol * u.m**-1 * u.s**-1 * u.mbar**-0.5,
+    act_energy=58 * u.kJ * u.mol**-1,
     source="houben_comparison_2022",
     isotope="D",
 )
 
 kishimoto_permeability = Permeability(
-    pre_exp=7.1e3
-    * htm.ureg.ccNTP
-    * htm.ureg.mm
-    * htm.ureg.cm**-2
-    * htm.ureg.h**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=0.69 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=7.1e3 * u.ccNTP * u.mm * u.cm**-2 * u.h**-1 * u.MPa**-0.5,
+    act_energy=0.69 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_diffusivity = Diffusivity(
-    D_0=1.3e-2 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.52 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=1.3e-2 * u.cm**2 * u.s**-1,
+    E_D=0.52 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 kishimoto_solubility = Solubility(
-    S_0=16 * htm.ureg.ccNTP * htm.ureg.cm**-3 * htm.ureg.MPa**-0.5,
-    E_S=0.13 * htm.ureg.eV * htm.ureg.particle**-1,
+    S_0=16 * u.ccNTP * u.cm**-3 * u.MPa**-0.5,
+    E_S=0.13 * u.eV * u.particle**-1,
     isotope="H",
-    range=(873 * htm.ureg.K, 1173 * htm.ureg.K),
+    range=(873 * u.K, 1173 * u.K),
     source="kishimoto_hydrogen_1985",
 )
 
 esteban_dissociation_coeff_clean = DissociationCoeff(
-    pre_exp=1.6e-3
-    * htm.ureg.mol
-    * htm.ureg.m**-2
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-1,
-    act_energy=48.2 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=1.6e-3 * u.mol * u.m**-2 * u.s**-1 * u.Pa**-1,
+    act_energy=48.2 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="clean surface, stationary",
 )
 
 esteban_recombination_coeff_clean = RecombinationCoeff(
-    pre_exp=6.8e-3 * htm.ureg.mol**-1 * htm.ureg.m**4 * htm.ureg.s**-1,
-    act_energy=20.4 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=6.8e-3 * u.mol**-1 * u.m**4 * u.s**-1,
+    act_energy=20.4 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="clean surface, stationary",
 )
 
 esteban_dissociation_coeff_oxidised = DissociationCoeff(
-    pre_exp=1.3e-6
-    * htm.ureg.mol
-    * htm.ureg.m**-2
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-1,
-    act_energy=68.9 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=1.3e-6 * u.mol * u.m**-2 * u.s**-1 * u.Pa**-1,
+    act_energy=68.9 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="oxidised surface, stationary",
 )
 
 esteban_recombination_coeff_oxidised = RecombinationCoeff(
-    pre_exp=5.5e-6 * htm.ureg.mol**-1 * htm.ureg.m**4 * htm.ureg.s**-1,
-    act_energy=41.2 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=5.5e-6 * u.mol**-1 * u.m**4 * u.s**-1,
+    act_energy=41.2 * u.kJ * u.mol**-1,
     isotope="T",
-    range=(450 * htm.ureg.K, 620 * htm.ureg.K),
+    range=(450 * u.K, 620 * u.K),
     source="perujo_low_1996",
     note="oxidised surface, stationary",
 )
 
 # TODO fit Forcey data ourselves
 forcey_permeability = Permeability(
-    pre_exp=1.80e-7
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5,
-    act_energy=64030 * htm.ureg.J * htm.ureg.mol**-1,
+    pre_exp=1.80e-7 * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5,
+    act_energy=64030 * u.J * u.mol**-1,
     range=(
-        htm.ureg.Quantity(250, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(250, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="forcey_hydrogen_1988",
 )
 
 forcey_diffusivity = Diffusivity(
-    D_0=3.82e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=45500 * htm.ureg.J * htm.ureg.mol**-1,
+    D_0=3.82e-7 * u.m**2 * u.s**-1,
+    E_D=45500 * u.J * u.mol**-1,
     range=(
-        htm.ureg.Quantity(250, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(250, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="forcey_hydrogen_1988",
 )
 
 forcey_solubility = Solubility(
-    S_0=1.50 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=18510 * htm.ureg.J * htm.ureg.mol**-1,
+    S_0=1.50 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=18510 * u.J * u.mol**-1,
     range=(
-        htm.ureg.Quantity(250, htm.ureg.degC),
-        htm.ureg.Quantity(600, htm.ureg.degC),
+        u.Quantity(250, u.degC),
+        u.Quantity(600, u.degC),
     ),
     isotope="H",
     source="forcey_hydrogen_1988",
 )
 
 xiukui_permeability = Permeability(
-    pre_exp=3.90e-4
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.MPa**-0.5,
-    act_energy=64.06 * htm.ureg.kJ * htm.ureg.mol**-1,
+    pre_exp=3.90e-4 * u.mol * u.m**-1 * u.s**-1 * u.MPa**-0.5,
+    act_energy=64.06 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(200, htm.ureg.degC),
-        htm.ureg.Quantity(430, htm.ureg.degC),
+        u.Quantity(200, u.degC),
+        u.Quantity(430, u.degC),
     ),
     isotope="H",
     source="xiukui_hydrogen_1989",
 )
 
 xiukui_diffusivity = Diffusivity(
-    D_0=4.79e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=51.59 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=4.79e-7 * u.m**2 * u.s**-1,
+    E_D=51.59 * u.kJ * u.mol**-1,
     range=(
-        htm.ureg.Quantity(200, htm.ureg.degC),
-        htm.ureg.Quantity(430, htm.ureg.degC),
+        u.Quantity(200, u.degC),
+        u.Quantity(430, u.degC),
     ),
     isotope="H",
     source="xiukui_hydrogen_1989",
@@ -185,14 +158,10 @@ lee_permeability_data = np.genfromtxt(
     delimiter=",",
     names=True,
 )
-lee_data_invT = lee_permeability_data["X"] * htm.ureg.K**-1
+lee_data_invT = lee_permeability_data["X"] * u.K**-1
 lee_permeability = Permeability(
     data_T=1 / lee_data_invT,
-    data_y=lee_permeability_data["Y"]
-    * htm.ureg.mol
-    * htm.ureg.s**-1
-    * htm.ureg.m**-1
-    * htm.ureg.Pa**-0.5,
+    data_y=lee_permeability_data["Y"] * u.mol * u.s**-1 * u.m**-1 * u.Pa**-0.5,
     isotope="H",
     source="lee_hydrogen_2011",
 )
@@ -202,20 +171,17 @@ lee_diffsol_data = np.genfromtxt(
     delimiter=",",
     names=True,
 )
-lee_data_invT = lee_diffsol_data["diffusivityX"] * htm.ureg.K**-1
+lee_data_invT = lee_diffsol_data["diffusivityX"] * u.K**-1
 lee_diffusivity = Diffusivity(
     data_T=1 / lee_data_invT,
-    data_y=lee_diffsol_data["diffusivityY"] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_y=lee_diffsol_data["diffusivityY"] * u.m**2 * u.s**-1,
     isotope="H",
     source="lee_hydrogen_2011",
 )
-lee_data_invT = lee_diffsol_data["solubilityX"] * htm.ureg.K**-1
+lee_data_invT = lee_diffsol_data["solubilityX"] * u.K**-1
 lee_solubility = Solubility(
     data_T=1 / lee_data_invT,
-    data_y=lee_diffsol_data["solubilityY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
+    data_y=lee_diffsol_data["solubilityY"] * u.mol * u.m**-3 * u.Pa**-0.5,
     isotope="H",
     source="lee_hydrogen_2011",
 )
@@ -227,26 +193,22 @@ serra_data = np.genfromtxt(
 )
 
 serra_permeability = Permeability(
-    data_T=1 / serra_data["permx"] * htm.ureg.K,
-    data_y=serra_data["permy"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5,
+    data_T=1 / serra_data["permx"] * u.K,
+    data_y=serra_data["permy"] * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5,
     isotope="H",
     source="serra_hydrogen_2004",
 )
 
 serra_diffusivity = Diffusivity(
-    data_T=1 / serra_data["diffx"] * htm.ureg.K,
-    data_y=serra_data["diffy"] * htm.ureg.m**2 * htm.ureg.s**-1,
+    data_T=1 / serra_data["diffx"] * u.K,
+    data_y=serra_data["diffy"] * u.m**2 * u.s**-1,
     isotope="H",
     source="serra_hydrogen_2004",
 )
 
 serra_solubility = Solubility(
-    data_T=1 / serra_data["solx"] * htm.ureg.K,
-    data_y=serra_data["soly"] * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
+    data_T=1 / serra_data["solx"] * u.K,
+    data_y=serra_data["soly"] * u.mol * u.m**-3 * u.Pa**-0.5,
     isotope="H",
     source="serra_hydrogen_2004",
 )

--- a/h_transport_materials/property_database/tantalum.py
+++ b/h_transport_materials/property_database/tantalum.py
@@ -1,21 +1,21 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 
+u = htm.ureg
 
 volkl_diffusivity = Diffusivity(
-    D_0=4.40e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=13.5 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(253 * htm.ureg.K, 573 * htm.ureg.K),
+    D_0=4.40e-8 * u.m**2 * u.s**-1,
+    E_D=13.5 * u.kJ * u.mol**-1,
+    range=(253 * u.K, 573 * u.K),
     isotope="H",
     source="volkl_5_1975",
 )
 
 veleckis_solubility = Solubility(
-    S_0=1.32e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=-33.7 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=1.32e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=-33.7 * u.kJ * u.mol**-1,
     isotope="H",
-    range=(623 * htm.ureg.K, 904 * htm.ureg.K),
+    range=(623 * u.K, 904 * u.K),
     source="veleckis_thermodynamic_1969",
 )
 

--- a/h_transport_materials/property_database/titanium.py
+++ b/h_transport_materials/property_database/titanium.py
@@ -1,26 +1,22 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-import h_transport_materials.conversion as c
 
+u = htm.ureg
 
 TITANIUM_MOLAR_VOLUME = 1.05e-5  # m3/mol https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/titanium
 
 reiter_diffusivity = Diffusivity(
-    D_0=6.9e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=49.1 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=6.9e-7 * u.m**2 * u.s**-1,
+    E_D=49.1 * u.kJ * u.mol**-1,
     source="reiter_compilation_1996",
     isotope="T",
-    range=(873 * htm.ureg.K, 1123 * htm.ureg.K),
+    range=(873 * u.K, 1123 * u.K),
 )
 
 reiter_solubility = Solubility(
-    S_0=1.06e-5
-    / TITANIUM_MOLAR_VOLUME
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
-    E_S=-42.7 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(873 * htm.ureg.K, 1123 * htm.ureg.K),
+    S_0=1.06e-5 / TITANIUM_MOLAR_VOLUME * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=-42.7 * u.kJ * u.mol**-1,
+    range=(873 * u.K, 1123 * u.K),
     isotope="T",
     source="reiter_compilation_1996",
 )

--- a/h_transport_materials/property_database/tungsten/tungsten.py
+++ b/h_transport_materials/property_database/tungsten/tungsten.py
@@ -8,18 +8,20 @@ from h_transport_materials.property import (
 from pathlib import Path
 import numpy as np
 
+u = htm.ureg
+
 frauenfelder_src = "frauenfelder_solution_1969"
 frauenfelder_diffusivity = Diffusivity(
-    D_0=4.1e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.39 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(1100 * htm.ureg.K, 2400 * htm.ureg.K),
+    D_0=4.1e-7 * u.m**2 * u.s**-1,
+    E_D=0.39 * u.eV * u.particle**-1,
+    range=(1100 * u.K, 2400 * u.K),
     source=frauenfelder_src,
     isotope="H",
 )
 frauenfelder_solubility = Solubility(
-    S_0=1.87e24 * htm.ureg.particle * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=1.04 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(1100 * htm.ureg.K, 2400 * htm.ureg.K),
+    S_0=1.87e24 * u.particle * u.m**-3 * u.Pa**-0.5,
+    E_S=1.04 * u.eV * u.particle**-1,
+    range=(1100 * u.K, 2400 * u.K),
     source=frauenfelder_src,
     isotope="H",
 )
@@ -27,9 +29,9 @@ frauenfelder_solubility = Solubility(
 
 liu_src = "liu_hydrogen_2014"
 liu_diffusivity_tungsten = Diffusivity(
-    D_0=5.13e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.21 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(200 * htm.ureg.K, 3000 * htm.ureg.K),
+    D_0=5.13e-8 * u.m**2 * u.s**-1,
+    E_D=0.21 * u.eV * u.particle**-1,
+    range=(200 * u.K, 3000 * u.K),
     source=liu_src,
     isotope="H",
 )
@@ -37,33 +39,33 @@ liu_diffusivity_tungsten = Diffusivity(
 
 heinola_src = "heinola_diffusion_2010"
 heinola_diffusivity_tungsten = Diffusivity(
-    D_0=5.2e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.21 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=5.2e-8 * u.m**2 * u.s**-1,
+    E_D=0.21 * u.eV * u.particle**-1,
     source=heinola_src,
     isotope="H",
 )
 
 johnson_src = "johnson_hydrogen_2010"
 johnson_diffusivity_tungsten_h = Diffusivity(
-    D_0=6.32e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.39 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=6.32e-7 * u.m**2 * u.s**-1,
+    E_D=0.39 * u.eV * u.particle**-1,
     source=johnson_src,
     isotope="H",
 )
 
 johnson_diffusivity_tungsten_t = Diffusivity(
-    D_0=5.16e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.40 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=5.16e-7 * u.m**2 * u.s**-1,
+    E_D=0.40 * u.eV * u.particle**-1,
     source=johnson_src,
     isotope="T",
 )
 
 
 moore_diffusivity_tungsten_h = Diffusivity(
-    data_T=[1783.0, 1890.0, 1960.0, 2045.0, 2175.0] * htm.ureg.K,
+    data_T=[1783.0, 1890.0, 1960.0, 2045.0, 2175.0] * u.K,
     data_y=np.array([6.45e-9, 1.26e-8, 1.81e-8, 3.01e-8, 5.15e-8])
-    * htm.ureg.cm**2
-    * htm.ureg.s**-1,
+    * u.cm**2
+    * u.s**-1,
     source="moore_thermal_2004",
     isotope="H",
     note="data in table IV. Units are not given but on page 2651 the equation indiquates that D is in cm2/s",
@@ -71,199 +73,171 @@ moore_diffusivity_tungsten_h = Diffusivity(
 
 
 zakharov_diffusivity_tungsten_h = Diffusivity(
-    data_T=htm.ureg.Quantity(np.array([400, 600, 800, 1000, 1200]), htm.ureg.degC),
+    data_T=u.Quantity(np.array([400, 600, 800, 1000, 1200]), u.degC),
     data_y=np.array([6.43e-8, 4.22e-6, 5.99e-5, 3.67e-4, 1.38e-3])
-    * htm.ureg.cm**2
-    * htm.ureg.s**-1,
+    * u.cm**2
+    * u.s**-1,
     source="zakharov_hydrogen_1975",
     isotope="H",
     note="the author gives activation energies in cal",
 )
 
 ryabchikov_diffusivity_tungsten_h = Diffusivity(
-    D_0=8.1e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=82.9 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(1055 * htm.ureg.K, 1570 * htm.ureg.K),
+    D_0=8.1e-6 * u.m**2 * u.s**-1,
+    E_D=82.9 * u.kJ * u.mol**-1,
+    range=(1055 * u.K, 1570 * u.K),
     source="ryabchikov_notitle_1964",
     isotope="H",
 )
 
 esteban_src = "esteban_hydrogen_2001"
 esteban_diffusivity_tungsten_h = Diffusivity(
-    D_0=5.68e-10 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=9.3 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    D_0=5.68e-10 * u.m**2 * u.s**-1,
+    E_D=9.3 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     source=esteban_src,
     isotope="H",
 )
 
 esteban_diffusivity_tungsten_d = Diffusivity(
-    D_0=5.49e-10 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=10 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    D_0=5.49e-10 * u.m**2 * u.s**-1,
+    E_D=10 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     source=esteban_src,
     isotope="D",
 )
 
 esteban_diffusivity_tungsten_t = Diffusivity(
-    D_0=5.34e-10 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=11.2 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    D_0=5.34e-10 * u.m**2 * u.s**-1,
+    E_D=11.2 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     source=esteban_src,
     isotope="T",
 )
 
 
 esteban_solubility_tungsten_h = Solubility(
-    S_0=2.9e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=26.9 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    S_0=2.9e-2 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=26.9 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     source=esteban_src,
     isotope="H",
 )
 
 esteban_solubility_tungsten_d = Solubility(
-    S_0=0.75e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=28.7 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    S_0=0.75e-2 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=28.7 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     source=esteban_src,
     isotope="D",
 )
 
 esteban_solubility_tungsten_t = Solubility(
-    S_0=2.25e-2 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=27.8 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    S_0=2.25e-2 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=27.8 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     source=esteban_src,
     isotope="T",
 )
 
 holzner_src = "holzner_solute_2020"
 holzner_diffusivity_tungsten_h = Diffusivity(
-    D_0=2.06e-3 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.28 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(1600 * htm.ureg.K, 2600 * htm.ureg.K),
+    D_0=2.06e-3 * u.cm**2 * u.s**-1,
+    E_D=0.28 * u.eV * u.particle**-1,
+    range=(1600 * u.K, 2600 * u.K),
     source=holzner_src,
     isotope="H",
 )
 holzner_diffusivity_tungsten_d = Diffusivity(
-    D_0=1.60e-3 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.28 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(1600 * htm.ureg.K, 2600 * htm.ureg.K),
+    D_0=1.60e-3 * u.cm**2 * u.s**-1,
+    E_D=0.28 * u.eV * u.particle**-1,
+    range=(1600 * u.K, 2600 * u.K),
     source=holzner_src,
     isotope="D",
 )
 
 fernandez_diffusivity_tungsten_h = Diffusivity(
-    D_0=1.93e-7 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.20 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(300 * htm.ureg.K, 1200 * htm.ureg.K),
+    D_0=1.93e-7 * u.m**2 * u.s**-1,
+    E_D=0.20 * u.eV * u.particle**-1,
+    range=(300 * u.K, 1200 * u.K),
     source="fernandez_hydrogen_2015",
     isotope="H",
 )
 
 anderl_recomb = RecombinationCoeff(
-    pre_exp=3.2e-15 * htm.ureg.m**4 * htm.ureg.s**-1 * htm.ureg.particle**-1,
-    act_energy=1.16 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=3.2e-15 * u.m**4 * u.s**-1 * u.particle**-1,
+    act_energy=1.16 * u.eV * u.particle**-1,
     isotope="D",
     source="anderl_deuterium_1992",
 )
 
-frauenfelder_p_0 = (
-    1.5e-3
-    * htm.ureg.torr
-    * htm.ureg.liter
-    * htm.ureg.cm**-1
-    * htm.ureg.s**-1
-    * htm.ureg.torr**-0.5
-)
+frauenfelder_p_0 = 1.5e-3 * u.torr * u.liter * u.cm**-1 * u.s**-1 * u.torr**-0.5
 frauenfelder_permeability = Permeability(
-    pre_exp=frauenfelder_p_0 / (htm.Rg * 300 * htm.ureg.K),
-    act_energy=31.5 * htm.ureg.kcal * htm.ureg.mol**-1,
+    pre_exp=frauenfelder_p_0 / (htm.Rg * 300 * u.K),
+    act_energy=31.5 * u.kcal * u.mol**-1,
     isotope="H",
     range=(
-        htm.ureg.Quantity(1050, htm.ureg.degC),
-        htm.ureg.Quantity(2400, htm.ureg.degC),
+        u.Quantity(1050, u.degC),
+        u.Quantity(2400, u.degC),
     ),
     source="frauenfelder_permeation_1968",
 )
 
 zakharov_permeability = Permeability(
-    pre_exp=5.2e-3
-    * htm.ureg.ccNTP
-    * htm.ureg.cm
-    * htm.ureg.cm**-2
-    * htm.ureg.s**-1
-    * htm.ureg.atm**-0.5,
-    act_energy=25400 * htm.ureg.cal * htm.ureg.mol**-1,
+    pre_exp=5.2e-3 * u.ccNTP * u.cm * u.cm**-2 * u.s**-1 * u.atm**-0.5,
+    act_energy=25400 * u.cal * u.mol**-1,
     source="zakharov_hydrogen_1975",
     isotope="H",
     range=(
-        htm.ureg.Quantity(400, htm.ureg.degC),
-        htm.ureg.Quantity(1200, htm.ureg.degC),
+        u.Quantity(400, u.degC),
+        u.Quantity(1200, u.degC),
     ),
     note="the author gives activation energies in cal",
 )
 
 esteban_permeability_h = Permeability(
-    pre_exp=1.65e-11
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.Pa**-0.5
-    * htm.ureg.s**-1,
-    act_energy=36.2 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    pre_exp=1.65e-11 * u.mol * u.m**-1 * u.Pa**-0.5 * u.s**-1,
+    act_energy=36.2 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     isotope="H",
     source="esteban_hydrogen_2001",
 )
 
 esteban_permeability_d = Permeability(
-    pre_exp=1.51e-11
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.Pa**-0.5
-    * htm.ureg.s**-1,
-    act_energy=38.7 * htm.ureg.kJ * htm.ureg.mol**-1,
-    range=(673 * htm.ureg.K, 1073 * htm.ureg.K),
+    pre_exp=1.51e-11 * u.mol * u.m**-1 * u.Pa**-0.5 * u.s**-1,
+    act_energy=38.7 * u.kJ * u.mol**-1,
+    range=(673 * u.K, 1073 * u.K),
     isotope="D",
     source="esteban_hydrogen_2001",
 )
 
 # TODO fit this ourselves
 zhao_permeability = Permeability(
-    pre_exp=3.2e-8
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.Pa**-0.5
-    * htm.ureg.s**-1,
-    act_energy=0.81 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=3.2e-8 * u.mol * u.m**-1 * u.Pa**-0.5 * u.s**-1,
+    act_energy=0.81 * u.eV * u.particle**-1,
     isotope="D",
-    range=(627 * htm.ureg.K, 965 * htm.ureg.K),
+    range=(627 * u.K, 965 * u.K),
     source="zhao_deuterium_2020",
     note="undamaged W",
 )
 
 zhao_diffusivity = Diffusivity(
-    D_0=3.0e-6 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=0.64 * htm.ureg.eV * htm.ureg.particle**-1,
+    D_0=3.0e-6 * u.m**2 * u.s**-1,
+    E_D=0.64 * u.eV * u.particle**-1,
     isotope="D",
-    range=(627 * htm.ureg.K, 965 * htm.ureg.K),
+    range=(627 * u.K, 965 * u.K),
     source="zhao_deuterium_2020",
     note="undamaged W",
 )
 
 
 liang_permeability = Permeability(
-    pre_exp=4.94e-7
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5,
-    act_energy=1.38 * htm.ureg.eV * htm.ureg.particle**-1,
+    pre_exp=4.94e-7 * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5,
+    act_energy=1.38 * u.eV * u.particle**-1,
     isotope="D",
     range=(
-        htm.ureg.Quantity(600, htm.ureg.degC),
-        htm.ureg.Quantity(800, htm.ureg.degC),
+        u.Quantity(600, u.degC),
+        u.Quantity(800, u.degC),
     ),
     source="liang_deuterium_2018",
 )
@@ -282,13 +256,9 @@ liu_diffusivity_data = np.genfromtxt(
     names=True,
 )
 
-rolled_50um_data_invT = liu_permeability_data["rolled_50umX"] * htm.ureg.K**-1
+rolled_50um_data_invT = liu_permeability_data["rolled_50umX"] * u.K**-1
 rolled_50um_data_y = (
-    liu_permeability_data["rolled_50umY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5
+    liu_permeability_data["rolled_50umY"] * u.mol * u.m**-1 * u.s**-1 * u.Pa**-0.5
 )
 liu_permeability_rolled_50um = Permeability(
     data_T=1 / rolled_50um_data_invT,
@@ -298,13 +268,13 @@ liu_permeability_rolled_50um = Permeability(
     isotope="H",
 )
 
-rolled_114um_data_invT = liu_permeability_data["rolled_114umX"] * htm.ureg.K**-1
+rolled_114um_data_invT = liu_permeability_data["rolled_114umX"] * u.K**-1
 rolled_114um_data_y = (
     liu_permeability_data["rolled_114umY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5
+    * u.mol
+    * u.m**-1
+    * u.s**-1
+    * u.Pa**-0.5
 )
 liu_permeability_rolled_114um = Permeability(
     data_T=1 / rolled_114um_data_invT,
@@ -314,13 +284,13 @@ liu_permeability_rolled_114um = Permeability(
     isotope="H",
 )
 
-rolled_240um_data_invT = liu_permeability_data["rolled_240umX"] * htm.ureg.K**-1
+rolled_240um_data_invT = liu_permeability_data["rolled_240umX"] * u.K**-1
 rolled_240um_data_y = (
     liu_permeability_data["rolled_240umY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5
+    * u.mol
+    * u.m**-1
+    * u.s**-1
+    * u.Pa**-0.5
 )
 liu_permeability_rolled_240um = Permeability(
     data_T=1 / rolled_240um_data_invT,
@@ -330,13 +300,13 @@ liu_permeability_rolled_240um = Permeability(
     isotope="H",
 )
 
-annealed_50um_data_invT = liu_permeability_data["annealed_50umX"] * htm.ureg.K**-1
+annealed_50um_data_invT = liu_permeability_data["annealed_50umX"] * u.K**-1
 annealed_50um_data_y = (
     liu_permeability_data["annealed_50umY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5
+    * u.mol
+    * u.m**-1
+    * u.s**-1
+    * u.Pa**-0.5
 )
 liu_permeability_annealed_50um = Permeability(
     data_T=1 / annealed_50um_data_invT,
@@ -346,13 +316,13 @@ liu_permeability_annealed_50um = Permeability(
     note="annealed_50um",
 )
 
-annealed_250um_data_invT = liu_permeability_data["annealed_250umX"] * htm.ureg.K**-1
+annealed_250um_data_invT = liu_permeability_data["annealed_250umX"] * u.K**-1
 annealed_250um_data_y = (
     liu_permeability_data["annealed_250umY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5
+    * u.mol
+    * u.m**-1
+    * u.s**-1
+    * u.Pa**-0.5
 )
 liu_permeability_annealed_250um = Permeability(
     data_T=1 / annealed_250um_data_invT,
@@ -363,14 +333,14 @@ liu_permeability_annealed_250um = Permeability(
 )
 
 recrystallized_250um_data_invT = (
-    liu_permeability_data["recrystallized_250umX"] * htm.ureg.K**-1
+    liu_permeability_data["recrystallized_250umX"] * u.K**-1
 )
 recrystallized_250um_data_y = (
     liu_permeability_data["recrystallized_250umY"]
-    * htm.ureg.mol
-    * htm.ureg.m**-1
-    * htm.ureg.s**-1
-    * htm.ureg.Pa**-0.5
+    * u.mol
+    * u.m**-1
+    * u.s**-1
+    * u.Pa**-0.5
 )
 liu_permeability_recrystallized_250um = Permeability(
     data_T=1 / recrystallized_250um_data_invT,
@@ -381,10 +351,8 @@ liu_permeability_recrystallized_250um = Permeability(
 )
 
 
-rolled_114um_data_invT = liu_diffusivity_data["rolled_114umX"] * htm.ureg.K**-1
-rolled_114um_data_y = (
-    liu_diffusivity_data["rolled_114umY"] * htm.ureg.m**2 * htm.ureg.s**-1
-)
+rolled_114um_data_invT = liu_diffusivity_data["rolled_114umX"] * u.K**-1
+rolled_114um_data_y = liu_diffusivity_data["rolled_114umY"] * u.m**2 * u.s**-1
 liu_diffusivity_rolled_114um = Diffusivity(
     data_T=1 / rolled_114um_data_invT,
     data_y=rolled_114um_data_y,
@@ -393,10 +361,8 @@ liu_diffusivity_rolled_114um = Diffusivity(
     isotope="H",
 )
 
-rolled_240um_data_invT = liu_diffusivity_data["rolled_240umX"] * htm.ureg.K**-1
-rolled_240um_data_y = (
-    liu_diffusivity_data["rolled_240umY"] * htm.ureg.m**2 * htm.ureg.s**-1
-)
+rolled_240um_data_invT = liu_diffusivity_data["rolled_240umX"] * u.K**-1
+rolled_240um_data_y = liu_diffusivity_data["rolled_240umY"] * u.m**2 * u.s**-1
 liu_diffusivity_rolled_240um = Diffusivity(
     data_T=1 / rolled_240um_data_invT,
     data_y=rolled_240um_data_y,
@@ -405,10 +371,8 @@ liu_diffusivity_rolled_240um = Diffusivity(
     isotope="H",
 )
 
-annealed_102um_data_invT = liu_diffusivity_data["annealed_102umX"] * htm.ureg.K**-1
-annealed_102um_data_y = (
-    liu_diffusivity_data["annealed_102umY"] * htm.ureg.m**2 * htm.ureg.s**-1
-)
+annealed_102um_data_invT = liu_diffusivity_data["annealed_102umX"] * u.K**-1
+annealed_102um_data_y = liu_diffusivity_data["annealed_102umY"] * u.m**2 * u.s**-1
 liu_diffusivity_annealed_102um = Diffusivity(
     data_T=1 / annealed_102um_data_invT,
     data_y=annealed_102um_data_y,
@@ -417,10 +381,8 @@ liu_diffusivity_annealed_102um = Diffusivity(
     isotope="H",
 )
 
-annealed_250um_data_invT = liu_diffusivity_data["annealed_250umX"] * htm.ureg.K**-1
-annealed_250um_data_y = (
-    liu_diffusivity_data["annealed_250umY"] * htm.ureg.m**2 * htm.ureg.s**-1
-)
+annealed_250um_data_invT = liu_diffusivity_data["annealed_250umX"] * u.K**-1
+annealed_250um_data_y = liu_diffusivity_data["annealed_250umY"] * u.m**2 * u.s**-1
 liu_diffusivity_annealed_250um = Diffusivity(
     data_T=1 / annealed_250um_data_invT,
     data_y=annealed_250um_data_y,
@@ -431,10 +393,10 @@ liu_diffusivity_annealed_250um = Diffusivity(
 
 
 recrystallized_250um_data_invT = (
-    liu_diffusivity_data["recrystallized_250umX"] * htm.ureg.K**-1
+    liu_diffusivity_data["recrystallized_250umX"] * u.K**-1
 )
 recrystallized_250um_data_y = (
-    liu_diffusivity_data["recrystallized_250umY"] * htm.ureg.m**2 * htm.ureg.s**-1
+    liu_diffusivity_data["recrystallized_250umY"] * u.m**2 * u.s**-1
 )
 liu_diffusivity_recrystallized_250um = Diffusivity(
     data_T=1 / recrystallized_250um_data_invT,

--- a/h_transport_materials/property_database/vanadium_alloy.py
+++ b/h_transport_materials/property_database/vanadium_alloy.py
@@ -1,22 +1,23 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
 
+u = htm.ureg
 
 hashizume_diffusivity = Diffusivity(
-    D_0=7.50e-4 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=0.13 * htm.ureg.eV * htm.ureg.particle**-1,
-    range=(373 * htm.ureg.K, 573 * htm.ureg.K),
+    D_0=7.50e-4 * u.cm**2 * u.s**-1,
+    E_D=0.13 * u.eV * u.particle**-1,
+    range=(373 * u.K, 573 * u.K),
     isotope="T",
     source="hashizume_diffusional_2007",
     note="there is a conversion mistake for D_0 in Shimada 2020 review",
 )
 
 klepikov_solubility = Solubility(
-    data_T=[673.0, 773.0, 873.0, 973.0, 1073.0] * htm.ureg.K,
+    data_T=[673.0, 773.0, 873.0, 973.0, 1073.0] * u.K,
     data_y=[1.62e20, 9.84e19, 5.65e19, 4.91e19, 2.94e19]
-    * htm.ureg.particle
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
+    * u.particle
+    * u.m**-3
+    * u.Pa**-0.5,
     isotope="H",
     source="klepikov_hydrogen_2000",
     note="taken from Table 2",

--- a/h_transport_materials/property_database/zirconium/zirconium.py
+++ b/h_transport_materials/property_database/zirconium/zirconium.py
@@ -1,33 +1,33 @@
 import h_transport_materials as htm
 from h_transport_materials import Diffusivity, Solubility
-
 import numpy as np
 from pathlib import Path
 
+u = htm.ureg
 
 ZIRCONIUM_MOLAR_VOLUME = 1.4e-5  # m3/mol https://www.aqua-calc.com/calculate/mole-to-volume-and-weight/substance/zirconium
 
 kearns_diffusivity = Diffusivity(
-    D_0=7.73e-3 * htm.ureg.cm**2 * htm.ureg.s**-1,
-    E_D=10.830 * htm.ureg.kcal * htm.ureg.mol**-1,
-    range=(548 * htm.ureg.K, 973 * htm.ureg.K),
+    D_0=7.73e-3 * u.cm**2 * u.s**-1,
+    E_D=10.830 * u.kcal * u.mol**-1,
+    range=(548 * u.K, 973 * u.K),
     isotope="H",
     source="kearns_diffusion_1972",
 )
 
 hsu_diffusivity = Diffusivity(
-    D_0=2.7e-8 * htm.ureg.m**2 * htm.ureg.s**-1,
-    E_D=24.9 * htm.ureg.kJ * htm.ureg.mol**-1,
+    D_0=2.7e-8 * u.m**2 * u.s**-1,
+    E_D=24.9 * u.kJ * u.mol**-1,
     isotope="T",
     source="hsu_palladium-catalyzed_1986",
 )
 
 kearns_solubility = Solubility(
-    S_0=4.30e-1 * htm.ureg.mol * htm.ureg.m**-3 * htm.ureg.Pa**-0.5,
-    E_S=-49.5 * htm.ureg.kJ * htm.ureg.mol**-1,
+    S_0=4.30e-1 * u.mol * u.m**-3 * u.Pa**-0.5,
+    E_S=-49.5 * u.kJ * u.mol**-1,
     isotope="H",
     source="kearns_terminal_1967",
-    range=(602 * htm.ureg.K, 1069 * htm.ureg.K),
+    range=(602 * u.K, 1069 * u.K),
     note="this was found in Shimada 2020 review 'Tritium Transport in Fusion Reactor Materials'"
     + "however, I can't find this activation energy in Kearns paper",
 )
@@ -38,12 +38,12 @@ yamanaka_solubility_data = np.genfromtxt(
 )
 
 yamanaka_solubility = Solubility(
-    data_T=1e4 / yamanaka_solubility_data[:, 0] * htm.ureg.K,
+    data_T=1e4 / yamanaka_solubility_data[:, 0] * u.K,
     data_y=np.exp(yamanaka_solubility_data[:, 1])
     / ZIRCONIUM_MOLAR_VOLUME
-    * htm.ureg.mol
-    * htm.ureg.m**-3
-    * htm.ureg.Pa**-0.5,
+    * u.mol
+    * u.m**-3
+    * u.Pa**-0.5,
     source="yamanaka_effect_1989",
     isotope="H",
 )


### PR DESCRIPTION
Noticed there was a discrepancy in some newer scripts there is the use of:
```python
u = htm.ureg
```
However, in older scripts, this is not the case. Gone through and updated all the scripts to use the same format, improving the consistency in the repo and the readability of the units

Also removed some lines of code in headers which weren't used in certain scripts