### PR TITLE
removed system packages: false

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,4 +11,3 @@ python:
      - requirements: docs/requirements.txt
      - method: pip
        path: .
-   system_packages: false


### PR DESCRIPTION
documentation builds recently started failing #264 

[Removing system packages: false in the yaml file should fix this](https://github.com/readthedocs/readthedocs.org/pull/10562#issuecomment-1698111020).

