### PR TITLE
Schober/Qi diffusivities for V, Nb and Ta

### DIFF
--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -35,23 +35,23 @@ qi_diffusivity_d = Diffusivity(
     isotope="D",
 )
 
-qi_diffusivity_h_low_temp = Diffusivity(
+qi_diffusivity_h_high_temp = Diffusivity(
     D_0=5e-4 * u.cm**2 * u.s**-1,
     E_D=0.106 * u.eV * u.particle**-1,
     range=(
-        u.Quantity(-140, u.degC),
         250 * u.K,
+        u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
     isotope="H",
 )
 
-qi_diffusivity_h_high_temp = Diffusivity(
+qi_diffusivity_h_low_temp = Diffusivity(
     D_0=0.9 * u.cm**2 * u.s**-1,
     E_D=0.068 * u.eV * u.particle**-1,
     range=(
+        u.Quantity(-140, u.degC),
         250 * u.K,
-        u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
     isotope="H",

--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -19,6 +19,7 @@ qi_diffusivity_t = Diffusivity(
         u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
+    note="table 1",
     isotope="T",
 )
 
@@ -30,6 +31,7 @@ qi_diffusivity_d = Diffusivity(
         u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
+    note="table 1",
     isotope="D",
 )
 
@@ -41,17 +43,19 @@ qi_diffusivity_h_high_temp = Diffusivity(
         u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
+    note="table 1",
     isotope="H",
 )
 
 qi_diffusivity_h_low_temp = Diffusivity(
-    D_0=0.9 * u.cm**2 * u.s**-1,
+    D_0=0.9e-4 * u.cm**2 * u.s**-1,
     E_D=0.068 * u.eV * u.particle**-1,
     range=(
         u.Quantity(-160, u.degC),
         250 * u.K,
     ),
     source="qi_tritium_1983",
+    note="table 1",
     isotope="H",
 )
 

--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -19,7 +19,7 @@ qi_diffusivity_t = Diffusivity(
         u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     isotope="T",
 )
 
@@ -31,7 +31,7 @@ qi_diffusivity_d = Diffusivity(
         u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     isotope="D",
 )
 
@@ -43,7 +43,7 @@ qi_diffusivity_h_high_temp = Diffusivity(
         u.Quantity(100, u.degC),
     ),
     source="qi_tritium_1983",
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     isotope="H",
 )
 
@@ -55,7 +55,7 @@ qi_diffusivity_h_low_temp = Diffusivity(
         250 * u.K,
     ),
     source="qi_tritium_1983",
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     isotope="H",
 )
 

--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -50,7 +50,7 @@ qi_diffusivity_h_low_temp = Diffusivity(
     D_0=0.9 * u.cm**2 * u.s**-1,
     E_D=0.068 * u.eV * u.particle**-1,
     range=(
-        u.Quantity(-140, u.degC),
+        u.Quantity(-160, u.degC),
         250 * u.K,
     ),
     source="qi_tritium_1983",

--- a/h_transport_materials/property_database/niobium.py
+++ b/h_transport_materials/property_database/niobium.py
@@ -13,9 +13,8 @@ volkl_diffusivity = Diffusivity(
     isotope="H",
 )
 
-# TODO issue #64
-qi_diffusivity = Diffusivity(
-    D_0=4.4e-8 * u.m**2 * u.s**-1,
+qi_diffusivity_t = Diffusivity(
+    D_0=4.4e-4 * u.cm**2 * u.s**-1,
     E_D=0.133 * u.eV * u.particle**-1,
     range=(
         u.Quantity(-140, u.degC),
@@ -23,6 +22,39 @@ qi_diffusivity = Diffusivity(
     ),
     source="qi_tritium_1983",
     isotope="T",
+)
+
+qi_diffusivity_d = Diffusivity(
+    D_0=5.2e-4 * u.cm**2 * u.s**-1,
+    E_D=0.127 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-140, u.degC),
+        u.Quantity(100, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="D",
+)
+
+qi_diffusivity_h_low_temp = Diffusivity(
+    D_0=5e-4 * u.cm**2 * u.s**-1,
+    E_D=0.106 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-140, u.degC),
+        250 * u.K,
+    ),
+    source="qi_tritium_1983",
+    isotope="H",
+)
+
+qi_diffusivity_h_high_temp = Diffusivity(
+    D_0=0.9 * u.cm**2 * u.s**-1,
+    E_D=0.068 * u.eV * u.particle**-1,
+    range=(
+        250 * u.K,
+        u.Quantity(100, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="H",
 )
 
 veleckis_solubility = Solubility(
@@ -35,7 +67,10 @@ veleckis_solubility = Solubility(
 
 properties = [
     volkl_diffusivity,
-    qi_diffusivity,
+    qi_diffusivity_t,
+    qi_diffusivity_d,
+    qi_diffusivity_h_low_temp,
+    qi_diffusivity_h_high_temp,
     veleckis_solubility,
 ]
 

--- a/h_transport_materials/property_database/tantalum.py
+++ b/h_transport_materials/property_database/tantalum.py
@@ -19,7 +19,59 @@ veleckis_solubility = Solubility(
     source="veleckis_thermodynamic_1969",
 )
 
-properties = [volkl_diffusivity, veleckis_solubility]
+
+qi_diffusivity_h_low_temp = Diffusivity(
+    D_0=0.028 * u.cm**2 * u.s**-1,
+    E_D=0.042 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-140, u.degC),
+        250 * u.K,
+    ),
+    source="qi_tritium_1983",
+    isotope="H",
+)
+
+qi_diffusivity_h_high_temp = Diffusivity(
+    D_0=4.2 * u.cm**2 * u.s**-1,
+    E_D=0.136 * u.eV * u.particle**-1,
+    range=(
+        250 * u.K,
+        u.Quantity(100, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="H",
+)
+
+qi_diffusivity_d = Diffusivity(
+    D_0=2.8 * u.cm**2 * u.s**-1,
+    E_D=0.153 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-140, u.degC),
+        u.Quantity(100, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="D",
+)
+
+qi_diffusivity_t = Diffusivity(
+    D_0=3.7 * u.cm**2 * u.s**-1,
+    E_D=0.162 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-140, u.degC),
+        u.Quantity(100, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="T",
+)
+
+properties = [
+    volkl_diffusivity,
+    veleckis_solubility,
+    qi_diffusivity_h_low_temp,
+    qi_diffusivity_h_high_temp,
+    qi_diffusivity_d,
+    qi_diffusivity_t,
+]
 
 for prop in properties:
     prop.material = htm.TANTALUM

--- a/h_transport_materials/property_database/tantalum.py
+++ b/h_transport_materials/property_database/tantalum.py
@@ -24,7 +24,7 @@ qi_diffusivity_h_low_temp = Diffusivity(
     D_0=0.028 * u.cm**2 * u.s**-1,
     E_D=0.042 * u.eV * u.particle**-1,
     range=(
-        u.Quantity(-140, u.degC),
+        u.Quantity(-180, u.degC),
         250 * u.K,
     ),
     source="qi_tritium_1983",

--- a/h_transport_materials/property_database/tantalum.py
+++ b/h_transport_materials/property_database/tantalum.py
@@ -27,7 +27,7 @@ qi_diffusivity_h_low_temp = Diffusivity(
         u.Quantity(-180, u.degC),
         250 * u.K,
     ),
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     source="qi_tritium_1983",
     isotope="H",
 )
@@ -39,7 +39,7 @@ qi_diffusivity_h_high_temp = Diffusivity(
         250 * u.K,
         u.Quantity(100, u.degC),
     ),
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     source="qi_tritium_1983",
     isotope="H",
 )
@@ -51,7 +51,7 @@ qi_diffusivity_d = Diffusivity(
         u.Quantity(-140, u.degC),
         u.Quantity(100, u.degC),
     ),
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     source="qi_tritium_1983",
     isotope="D",
 )
@@ -63,7 +63,7 @@ qi_diffusivity_t = Diffusivity(
         u.Quantity(-140, u.degC),
         u.Quantity(100, u.degC),
     ),
-    note="table 1",
+    note="table 1, temperature range from Fig 1",
     source="qi_tritium_1983",
     isotope="T",
 )

--- a/h_transport_materials/property_database/tantalum.py
+++ b/h_transport_materials/property_database/tantalum.py
@@ -21,45 +21,49 @@ veleckis_solubility = Solubility(
 
 
 qi_diffusivity_h_low_temp = Diffusivity(
-    D_0=0.028 * u.cm**2 * u.s**-1,
+    D_0=0.028e-4 * u.cm**2 * u.s**-1,
     E_D=0.042 * u.eV * u.particle**-1,
     range=(
         u.Quantity(-180, u.degC),
         250 * u.K,
     ),
+    note="table 1",
     source="qi_tritium_1983",
     isotope="H",
 )
 
 qi_diffusivity_h_high_temp = Diffusivity(
-    D_0=4.2 * u.cm**2 * u.s**-1,
+    D_0=4.2e-4 * u.cm**2 * u.s**-1,
     E_D=0.136 * u.eV * u.particle**-1,
     range=(
         250 * u.K,
         u.Quantity(100, u.degC),
     ),
+    note="table 1",
     source="qi_tritium_1983",
     isotope="H",
 )
 
 qi_diffusivity_d = Diffusivity(
-    D_0=2.8 * u.cm**2 * u.s**-1,
+    D_0=3.8e-4 * u.cm**2 * u.s**-1,
     E_D=0.153 * u.eV * u.particle**-1,
     range=(
         u.Quantity(-140, u.degC),
         u.Quantity(100, u.degC),
     ),
+    note="table 1",
     source="qi_tritium_1983",
     isotope="D",
 )
 
 qi_diffusivity_t = Diffusivity(
-    D_0=3.7 * u.cm**2 * u.s**-1,
+    D_0=3.7e-4 * u.cm**2 * u.s**-1,
     E_D=0.162 * u.eV * u.particle**-1,
     range=(
         u.Quantity(-140, u.degC),
         u.Quantity(100, u.degC),
     ),
+    note="table 1",
     source="qi_tritium_1983",
     isotope="T",
 )

--- a/h_transport_materials/property_database/vanadium.py
+++ b/h_transport_materials/property_database/vanadium.py
@@ -27,6 +27,7 @@ qi_diffusivity_h = Diffusivity(
         u.Quantity(200, u.degC),
     ),
     source="qi_tritium_1983",
+    note="table 1, temperature range from Fig 1",
     isotope="H",
 )
 
@@ -38,6 +39,7 @@ qi_diffusivity_d = Diffusivity(
         u.Quantity(200, u.degC),
     ),
     source="qi_tritium_1983",
+    note="table 1, temperature range from Fig 1",
     isotope="D",
 )
 
@@ -49,6 +51,7 @@ qi_diffusivity_t = Diffusivity(
         u.Quantity(200, u.degC),
     ),
     source="qi_tritium_1983",
+    note="table 1, temperature range from Fig 1",
     isotope="T",
 )  # TODO get data from experimental points, see issue #64
 

--- a/h_transport_materials/property_database/vanadium.py
+++ b/h_transport_materials/property_database/vanadium.py
@@ -21,15 +21,37 @@ veleckis_solubility = Solubility(
     source="veleckis_thermodynamic_1969",
 )
 
-qi_diffusivity = Diffusivity(
-    D_0=5.6e-8 * u.m**2 * u.s**-1,
-    E_D=9.1 * u.kJ * u.mol**-1,
+qi_diffusivity_h = Diffusivity(
+    D_0=3.1e-4 * u.cm**2 * u.s**-1,
+    E_D=0.045 * u.eV * u.particle**-1,
     range=(
-        u.Quantity(-150, u.degC),
+        u.Quantity(-130, u.degC),
         u.Quantity(200, u.degC),
     ),
     source="qi_tritium_1983",
     isotope="H",
+)
+
+qi_diffusivity_d = Diffusivity(
+    D_0=3.8e-4 * u.cm**2 * u.s**-1,
+    E_D=0.073 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-130, u.degC),
+        u.Quantity(200, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="D",
+)
+
+qi_diffusivity_t = Diffusivity(
+    D_0=5.6e-4 * u.cm**2 * u.s**-1,
+    E_D=0.094 * u.eV * u.particle**-1,
+    range=(
+        u.Quantity(-130, u.degC),
+        u.Quantity(200, u.degC),
+    ),
+    source="qi_tritium_1983",
+    isotope="T",
 )  # TODO get data from experimental points, see issue #64
 
 malo_permeability = Permeability(
@@ -46,7 +68,9 @@ malo_permeability = Permeability(
 properties = [
     volk_diffusivity,
     veleckis_solubility,
-    qi_diffusivity,
+    qi_diffusivity_h,
+    qi_diffusivity_d,
+    qi_diffusivity_t,
     malo_permeability,
 ]
 


### PR DESCRIPTION
This closes #64 by adding the diffusivities from [Qi 1983](https://iopscience.iop.org/article/10.1088/0305-4608/13/10/015).

Even though the reference gives experimental points, I haven't included them since no raw data was provided. See #262 