### PR TITLE
Original units for W solubility Frauenfelder

### DIFF
--- a/h_transport_materials/property_database/tungsten/tungsten.py
+++ b/h_transport_materials/property_database/tungsten/tungsten.py
@@ -175,14 +175,13 @@ anderl_recomb = RecombinationCoeff(
 )
 
 frauenfelder_p_0 = 1.5e-3 * u.torr * u.liter * u.cm**-1 * u.s**-1 * u.torr**-0.5
+T_ref = 273 * u.K
+frauenfelder_p_0 *= 1 / (htm.Rg * T_ref)
 frauenfelder_permeability = Permeability(
-    pre_exp=frauenfelder_p_0 / (htm.Rg * 300 * u.K),
+    pre_exp=frauenfelder_p_0,
     act_energy=31.5 * u.kcal * u.mol**-1,
     isotope="H",
-    range=(
-        u.Quantity(1050, u.degC),
-        u.Quantity(2400, u.degC),
-    ),
+    range=(1050 * u.K, 2400 * u.K),
     source="frauenfelder_permeation_1968",
 )
 

--- a/h_transport_materials/property_database/tungsten/tungsten.py
+++ b/h_transport_materials/property_database/tungsten/tungsten.py
@@ -9,19 +9,22 @@ import numpy as np
 
 u = htm.ureg
 
-frauenfelder_src = "frauenfelder_solution_1969"
 frauenfelder_diffusivity = Diffusivity(
-    D_0=4.1e-7 * u.m**2 * u.s**-1,
-    E_D=0.39 * u.eV * u.particle**-1,
+    D_0=4.1e-3 * u.cm**2 * u.s**-1,
+    E_D=9000 * u.cal * u.mol**-1,
     range=(1100 * u.K, 2400 * u.K),
-    source=frauenfelder_src,
+    source="frauenfelder_solution_1969",
     isotope="H",
 )
+
+S_0 = 2.9e-1 * u.torr * u.liter * u.cm**-3 * u.torr**-0.5
+T_ref = 273 * u.K
+S_0 = S_0 / (htm.Rg * T_ref)
 frauenfelder_solubility = Solubility(
-    S_0=1.87e24 * u.particle * u.m**-3 * u.Pa**-0.5,
-    E_S=1.04 * u.eV * u.particle**-1,
+    S_0=S_0,
+    E_S=24000 * u.cal * u.mol**-1,
     range=(1100 * u.K, 2400 * u.K),
-    source=frauenfelder_src,
+    source="frauenfelder_solution_1969",
     isotope="H",
 )
 


### PR DESCRIPTION
Used the original units for Frauenfelder's solubility and diffusivity as suggested by @jhdark in #278 

The pre-exponential factor for solubility is now 8.88e+23 particles/m3/Pa0.5 instead of 1.87e24 previously...


<img width="314" alt="image" src="https://github.com/RemDelaporteMathurin/h-transport-materials/assets/40028739/fc1fca72-4924-4996-a16d-98400d0975fc">

Also changed the reference temperature for the conversion of Frauenfelder's permeability and fixed temperature range which was Celsius instead of K