### PR TITLE
Correct year of Moore and Unterwald reference from 2004 to 1964

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# macOS stuff
+.DS_Store

--- a/h_transport_materials/property_database/tungsten/tungsten.py
+++ b/h_transport_materials/property_database/tungsten/tungsten.py
@@ -70,7 +70,7 @@ johnson_diffusivity_tungsten_t = Diffusivity(
 moore_diffusivity_tungsten_h = Diffusivity(
     data_T=[1783.0, 1890.0, 1960.0, 2045.0, 2175.0] * u.K,
     data_y=np.array([6.45e-9, 1.26e-8, 1.81e-8, 3.01e-8, 5.15e-8]) * u.cm**2 * u.s**-1,
-    source="moore_thermal_2004",
+    source="moore_thermal_1964",
     isotope="H",
     note="data in table IV. Units are not given but on page 2651 the equation indiquates that D is in cm2/s",
 )

--- a/h_transport_materials/references.bib
+++ b/h_transport_materials/references.bib
@@ -2143,7 +2143,7 @@ Relevant obtained values of amounts of the released tritium and helium for all s
 	file = {ScienceDirect Full Text PDF:C\:\\Users\\remidm\\Zotero\\storage\\D7EH4G8B\\Braun et al. - 1980 - Determination of deuterium surface recombination r.pdf:application/pdf;ScienceDirect Snapshot:C\:\\Users\\remidm\\Zotero\\storage\\4AW33YKP\\0022311580902196.html:text/html;Snapshot:C\:\\Users\\remidm\\Zotero\\storage\\7UPDLW8V\\0022311580902196.html:text/html},
 }
 
-@article{moore_thermal_2004,
+@article{moore_thermal_1964,
 	title = {Thermal {Dissociation} of {Hydrogen}},
 	volume = {40},
 	issn = {0021-9606},
@@ -2155,7 +2155,7 @@ Relevant obtained values of amounts of the released tritium and helium for all s
 	journal = {The Journal of Chemical Physics},
 	author = {Moore, George E. and Unterwald, F. C.},
 	month = jun,
-	year = {2004},
+	year = {1964},
 	pages = {2639--2652},
 	file = {Full Text PDF:C\:\\Users\\remidm\\Zotero\\storage\\KV3BZHQ7\\Moore and Unterwald - 2004 - Thermal Dissociation of Hydrogen.pdf:application/pdf;Snapshot:C\:\\Users\\remidm\\Zotero\\storage\\X4R5995F\\Thermal-Dissociation-of-Hydrogen.html:text/html},
 }


### PR DESCRIPTION
Hi Rémi,
We noticed that the year for the Moore and Unterwald reference was wrong, so fixed it here. We didn't change the name of the PDF file, though, of course.
Cheers,
Christian and Khadidja (IAEA)